### PR TITLE
Change Dig Logo

### DIFF
--- a/src/chains/mainnet/dig.json
+++ b/src/chains/mainnet/dig.json
@@ -6,12 +6,12 @@
     "coin_type": "118",
     "min_tx_fee": "5000",
     "addr_prefix": "dig",
-    "logo": "https://digchain.org/wp-content/uploads/2018/09/DIG.png",
+    "logo": "https://digchain.org/wp-content/uploads/2021/08/dig_lockup_800x800-cropped.png",
     "assets": [{
         "base": "udig",
         "symbol": "DIG",
         "exponent": "6",
         "coingecko_id": "", 
-        "logo": "https://digchain.org/wp-content/uploads/2018/09/DIG.png"
+        "logo": "https://digchain.org/wp-content/uploads/2021/08/dig_lockup_800x800-cropped.png"
     }]
 }


### PR DESCRIPTION
We now use the new logo of Dig!