### PR TITLE
Fixed validators voting power value calculation

### DIFF
--- a/src/views/Staking.vue
+++ b/src/views/Staking.vue
@@ -327,6 +327,9 @@ export default {
     },
   },
   created() {
+    this.$http.getStakingPool().then(pool => {
+      this.stakingPool = pool.bondedToken
+    })
     this.getValidatorListByHeight()
     this.$http.getStakingParameters().then(res => {
       this.stakingParameters = res
@@ -378,7 +381,6 @@ export default {
               identities.push(identity)
             }
           }
-          this.stakingPool = total
           if (total > 100) {
             this.getValidatorListByHeight(100)
           }


### PR DESCRIPTION
Current validator's voting power calculation is wrong, because it does not depend on Total Bonded Coins of Chain, but it depends on total bonded coins of current [active/inactive] validators bonded tokens sum.

Compare with https://www.mintscan.io/, you will see the difference