### PR TITLE
Update sentinel.json

### DIFF
--- a/src/chains/mainnet/sentinel.json
+++ b/src/chains/mainnet/sentinel.json
@@ -4,7 +4,7 @@
     "rpc": ["https://rpc-sentinel.keplr.app:443", "https://rpc-sentinel.keplr.app:443"],
     "snapshot_provider": "",
     "sdk_version": "0.42.6",
-    "coin_type": "750",
+    "coin_type": "118",
     "min_tx_fee": "8000",
     "addr_prefix": "sent",
     "logo": "/logos/sentinel.png",


### PR DESCRIPTION
Slip044 registers sentinel as 811 coin-type, but in the binary, it's 118 itself.