### PR TITLE
fix: update likecoin prefix and sdk_version

### DIFF
--- a/src/chains/mainnet/likecoin.json
+++ b/src/chains/mainnet/likecoin.json
@@ -4,16 +4,16 @@
     "api": "https://mainnet-node.like.co",
     "rpc": ["https://mainnet-node.like.co:443/rpc/", "https://mainnet-node.like.co:443/rpc/"],
     "snapshot_provider": "",
-    "sdk_version": "0.45.0",
+    "sdk_version": "0.44.8",
     "coin_type": "118",
     "min_tx_fee": "3000",
-    "addr_prefix": "cosmos",
+    "addr_prefix": "like",
     "logo": "/logos/likecoin.png",
     "assets": [{
         "base": "nanolike",
         "symbol": "LIKE",
         "exponent": "9",
-        "coingecko_id": "likecoin", 
+        "coingecko_id": "likecoin",
         "logo": "/logos/likecoin.png"
     }]
 }


### PR DESCRIPTION
After v2.0.0 update, LikeCoin chain is updated to sdk v0.44.8, and changed prefix to `like`