### PR TITLE
Update likecoin sdk version

### DIFF
--- a/src/chains/mainnet/likecoin.json
+++ b/src/chains/mainnet/likecoin.json
@@ -4,7 +4,7 @@
     "api": "https://mainnet-node.like.co",
     "rpc": ["https://mainnet-node.like.co:443/rpc/", "https://mainnet-node.like.co:443/rpc/"],
     "snapshot_provider": "",
-    "sdk_version": "0.44.8",
+    "sdk_version": "0.45.6",
     "coin_type": "118",
     "min_tx_fee": "3000",
     "addr_prefix": "like",


### PR DESCRIPTION
We just updated to v3 which is based on 0.45.6 sdk
https://blog.like.co/en/likecoin-chain-upgrade-starferry-overview/