### PR TITLE
fix: add API endpoints, and fix run -> ist

### DIFF
--- a/src/chains/mainnet/agoric.json
+++ b/src/chains/mainnet/agoric.json
@@ -1,6 +1,6 @@
 {
     "chain_name": "agoric",
-    "api": ["https://api.agoric.sgtstake.com", "https://main.api.agoric.net"],
+    "api": ["https://agoric-lcd.stakely.io", "https://api.agoric.sgtstake.com", "https://agoric-api.polkachu.com", "https://api-agoric.nodes.guru", "https://agoric.stakesystems.io", "https://main.api.agoric.net"],
     "rpc": ["https://main.rpc.agoric.net:443", "https://main.rpc.agoric.net:443"],
     "snapshot_provider": "",
     "sdk_version": "0.41.3",
@@ -13,8 +13,8 @@
         "coingecko_id": "", 
         "logo": ""
     },{
-        "base": "urun",
-        "symbol": "RUN",
+        "base": "uist",
+        "symbol": "IST",
         "exponent": "6",
         "coingecko_id": "", 
         "logo": ""


### PR DESCRIPTION
Adds a load-balanced API endpoint, and additional individual endpoints for the ping.pub explorer.  Also renames run to ist.