### PR TITLE
feat: when opening a direct link tx whithout previously loading the d…

### DIFF
--- a/src/@core/layouts/utils.js
+++ b/src/@core/layouts/utils.js
@@ -57,11 +57,12 @@ export const isNavLinkActive = link => {
     chainCompare = router.currentRoute.params.chain === link.route.params.chain
   }
 
+  if (chainCompare) {
+    localStorage.setItem('selected_chain', link.route.params.chain)
+  }
+  
   return matchedRoutes.some(route => {
     const actived = (route.name === resolveRoutedName && chainCompare) || route.meta.navActiveLink === resolveRoutedName
-    if (actived) {
-      localStorage.setItem('selected_chain', link.route.params.chain)
-    }
     return actived
   })
 }


### PR DESCRIPTION
When opening a tx directly without previously visiting the website the `localStorage('selected_chain')` wasn't set leading to not showing transaction details

![image](https://user-images.githubusercontent.com/13049940/187659312-d551a0da-49e1-4b04-af32-c65a0338ca39.png)

![image](https://user-images.githubusercontent.com/13049940/187659394-b3ce5535-1398-4ece-a42d-1f61f361db16.png)
