### PR TITLE
Patch - Uptime and Block pages improper display for version less than 0.45

### DIFF
--- a/src/libs/fetch.js
+++ b/src/libs/fetch.js
@@ -62,19 +62,13 @@ export default class ChainFetch {
   async getLatestBlock(config = null) {
     const conf = config || this.getSelectedConfig()
     const ver = conf.sdk_version || '0.41'
-    if (ver && compareVersions(ver, '0.45') < 1) {
-      return this.get('/blocks/latest', config).then(data => Block.create(data))
-    }
-    return this.get('/cosmos/base/tendermint/v1beta1/blocks/latest', config).then(data => Block.create(data))
+    return (ver && compareVersions(ver, '0.45') < 1) ? this.get('/blocks/latest', config).then(data => Block.create(data)) : this.get('/cosmos/base/tendermint/v1beta1/blocks/latest', config).then(data => Block.create(data))
   }
 
   async getBlockByHeight(height, config = null) {
     const conf = config || this.getSelectedConfig()
     const ver = conf.sdk_version || '0.41'
-    if (ver && compareVersions(ver, '0.45') < 1) {
-      return this.get(`/blocks/${height}`, config).then(data => Block.create(data))
-    }
-    return this.get(`/cosmos/base/tendermint/v1beta1/blocks/${height}`, config).then(data => Block.create(data))
+    return (ver && compareVersions(ver, '0.45') < 1) ? this.get(`/blocks/${height}`, config).then(data => Block.create(data)) : this.get(`/cosmos/base/tendermint/v1beta1/blocks/${height}`, config).then(data => Block.create(data))
   }
 
   async getSlashingSigningInfo(config = null) {

--- a/src/views/Blocks.vue
+++ b/src/views/Blocks.vue
@@ -74,8 +74,9 @@ import {
   toDay, abbr, abbrMessage, tokenFormatter,
 } from '@/libs/utils'
 import { decodeTxRaw } from '@cosmjs/proto-signing'
-import { fromBase64 } from '@cosmjs/encoding'
+import { fromBase64, fromHex, toBase64 } from '@cosmjs/encoding'
 import Tx from '@/libs/data/tx'
+import compareVersions from 'compare-versions'
 // import fetch from 'node-fetch'
 
 export default {
@@ -160,11 +161,16 @@ export default {
     clearInterval(this.timer)
   },
   methods: {
+    hex2base64(v) {
+      return toBase64(fromHex(v))
+    },
     length: v => (Array.isArray(v) ? v.length : 0),
     shortHash: v => abbr(v),
     formatTime: v => toDay(v, 'from'),
     formatProposer(v) {
-      return getStakingValidatorByHex(this.$http.config.chain_name, v)
+      const conf = this.$http.getSelectedConfig()
+      const ver = conf.sdk_version || '0.41'
+      return (ver && compareVersions(ver, '0.45') < 1) ? getStakingValidatorByHex(this.$http.config.chain_name, this.hex2base64(v)) : getStakingValidatorByHex(this.$http.config.chain_name, v)
     },
     fetch() {
       this.$http.getLatestBlock().then(b => {

--- a/src/views/Uptime.vue
+++ b/src/views/Uptime.vue
@@ -109,6 +109,7 @@ import {
   consensusPubkeyToHexAddress, getCachedValidators, timeIn, toDay,
 } from '@/libs/utils'
 import { fromBech32, fromHex, toBase64 } from '@cosmjs/encoding'
+import compareVersions from 'compare-versions'
 
 export default {
   components: {
@@ -210,9 +211,17 @@ export default {
         }
 
         const sigs = this.initColor()
-        d.block.last_commit.signatures.forEach(x => {
-          if (x.validator_address) sigs[x.validator_address] = 'bg-success'
-        })
+        const conf = this.$http.getSelectedConfig()
+        const ver = conf.sdk_version || '0.41'
+        if (ver && compareVersions(ver, '0.45') < 1) {
+          d.block.last_commit.signatures.forEach(x => {
+            if (this.hex2base64(x.validator_address)) sigs[this.hex2base64(x.validator_address)] = 'bg-success'
+          })
+        } else {
+          d.block.last_commit.signatures.forEach(x => {
+            if (x.validator_address) sigs[x.validator_address] = 'bg-success'
+          })
+        }
         blocks.push({ sigs, height })
         this.blocks = blocks
 
@@ -236,9 +245,17 @@ export default {
         this.$http.getBlockByHeight(height).then(res => {
           resolve()
           const sigs = this.initColor()
-          res.block.last_commit.signatures.forEach(x => {
-            if (x.validator_address) sigs[x.validator_address] = 'bg-success'
-          })
+          const conf = this.$http.getSelectedConfig()
+          const ver = conf.sdk_version || '0.41'
+          if (ver && compareVersions(ver, '0.45') < 1) {
+            res.block.last_commit.signatures.forEach(x => {
+              if (this.hex2base64(x.validator_address)) sigs[this.hex2base64(x.validator_address)] = 'bg-success'
+            })
+          } else {
+            res.block.last_commit.signatures.forEach(x => {
+              if (x.validator_address) sigs[x.validator_address] = 'bg-success'
+            })
+          }
           this.$set(block, 'sigs', sigs)
         })
       }
@@ -246,9 +263,17 @@ export default {
     fetch_latest() {
       this.$http.getLatestBlock().then(res => {
         const sigs = this.initColor()
-        res.block.last_commit.signatures.forEach(x => {
-          if (x.validator_address) sigs[x.validator_address] = 'bg-success'
-        })
+        const conf = this.$http.getSelectedConfig()
+        const ver = conf.sdk_version || '0.41'
+        if (ver && compareVersions(ver, '0.45') < 1) {
+          res.block.last_commit.signatures.forEach(x => {
+            if (this.hex2base64(x.validator_address)) sigs[this.hex2base64(x.validator_address)] = 'bg-success'
+          })
+        } else {
+          res.block.last_commit.signatures.forEach(x => {
+            if (x.validator_address) sigs[x.validator_address] = 'bg-success'
+          })
+        }
         const block = this.blocks.find(b => b.height === res.block.last_commit.height)
         if (typeof block === 'undefined') { // mei
           // this.$set(block, 0, typeof sigs !== 'undefined')


### PR DESCRIPTION
After the update to `fech.js` the `UPTIME` and `BLOCK` pages for Cosmos SDK versions below `0.45` were displaying as completely down in up time and not resolving monikers in the block page with the proposer.

I refactored the fetching blocks to return using ternary.  

Uptime(Including saved validator uptime) and Blocks added a version check, and if below `0.45` then convert the validator HEX address to BASE64, otherwise don't alter it and continue on.

I tested changes on Dev environment and my public hosted version.

Still needing to fix:
**My Validator Uptime**
Because it gets the config of the blockchain from the navigation, it will use that chains version for all.  Need to alter so that it figures out the version of the chain that is being monitored.