### PR TITLE
Fix - Delegate/Redelegate decimal issue

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -581,7 +581,7 @@ export default {
       return this.delegations.map(x => {
         const rewards = this.rewards.find(r => r.validator_address === x.delegation.validator_address)
         const conf = this.$http.getSelectedConfig()
-        const decimal = conf.assets.exponent || '6'
+        const decimal = conf.assets[0].exponent || '6'
         return {
           valAddress: x.delegation.validator_address,
           validator: getStakingValidatorOperator(this.$store.state.chains.selected.chain_name, x.delegation.validator_address),
@@ -700,7 +700,7 @@ export default {
     },
     fetchAccount(address) {
       const conf = this.$http.getSelectedConfig()
-      const decimal = conf.assets.exponent || '6'
+      const decimal = conf.assets[0].exponent || '6'
       this.address = address
       this.$http.getBankAccountBalance(address).then(bal => {
         this.walletBalances = this.formatToken(bal)

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -469,7 +469,7 @@ import {
 } from 'bootstrap-vue'
 import {
   formatNumber, formatTokenAmount, isToken, percent, timeIn, toDay, toDuration, tokenFormatter, getLocalAccounts,
-  getStakingValidatorOperator,
+  getStakingValidatorOperator, formatToken,
 } from '@/libs/utils'
 import OperationModal from '@/views/components/OperationModal/index.vue'
 import Ripple from 'vue-ripple-directive'
@@ -580,10 +580,12 @@ export default {
     stakingList() {
       return this.delegations.map(x => {
         const rewards = this.rewards.find(r => r.validator_address === x.delegation.validator_address)
+        const conf = this.$http.getSelectedConfig()
+        const decimal = conf.assets.exponent || '6'
         return {
           valAddress: x.delegation.validator_address,
           validator: getStakingValidatorOperator(this.$store.state.chains.selected.chain_name, x.delegation.validator_address),
-          delegation: this.formatToken([x.balance]),
+          delegation: formatToken(x.balance, {}, decimal),
           rewards: rewards ? this.formatToken(rewards.reward) : '',
           action: '',
         }
@@ -697,6 +699,8 @@ export default {
       return '-'
     },
     fetchAccount(address) {
+      const conf = this.$http.getSelectedConfig()
+      const decimal = conf.assets.exponent || '6'
       this.address = address
       this.$http.getBankAccountBalance(address).then(bal => {
         this.walletBalances = this.formatToken(bal)

--- a/src/views/WalletAccountDetail.vue
+++ b/src/views/WalletAccountDetail.vue
@@ -621,12 +621,14 @@ export default {
     },
     deleTable() {
       const re = []
+      const conf = this.$http.getSelectedConfig()
+      const decimal = conf.assets.exponent || '6'
       if (this.reward.rewards && this.delegations && this.delegations.length > 0) {
         this.delegations.forEach(e => {
           const reward = this.reward.rewards.find(r => r.validator_address === e.delegation.validator_address)
           re.push({
             validator: getStakingValidatorOperator(this.$http.config.chain_name, e.delegation.validator_address, 8),
-            token: formatToken(e.balance, {}, 2),
+            token: formatToken(e.balance, {}, decimal),
             reward: tokenFormatter(reward.reward, this.denoms),
             action: e.delegation.validator_address,
           })

--- a/src/views/WalletAccountDetail.vue
+++ b/src/views/WalletAccountDetail.vue
@@ -622,7 +622,7 @@ export default {
     deleTable() {
       const re = []
       const conf = this.$http.getSelectedConfig()
-      const decimal = conf.assets.exponent || '6'
+      const decimal = conf.assets[0].exponent || '6'
       if (this.reward.rewards && this.delegations && this.delegations.length > 0) {
         this.delegations.forEach(e => {
           const reward = this.reward.rewards.find(r => r.validator_address === e.delegation.validator_address)

--- a/src/views/WalletDelegations.vue
+++ b/src/views/WalletDelegations.vue
@@ -119,6 +119,8 @@ export default {
   },
   computed: {
     formatedDelegations() {
+      const conf = this.$http.getSelectedConfig()
+      const decimal = conf.assets.exponent || '6'
       return this.delegations.map(x => ({
         validator: {
           logo: x.chain.logo,
@@ -128,13 +130,15 @@ export default {
         },
         delegator: x.keyname,
         delegator_address: x.delegation.delegator_address,
-        delegation: formatToken(x.balance),
+        delegation: formatToken(x.balance, {}, decimal),
         reward: this.findReward(x.delegation.delegator_address, x.delegation.validator_address),
         // action: '',
       }))
     },
     groupedDelegations() {
       const group = {}
+      const conf = this.$http.getSelectedConfig()
+      const decimal = conf.assets.exponent || '6'
       this.delegations.forEach(x => {
         const d = {
           validator: {
@@ -145,7 +149,7 @@ export default {
           },
           delegator: x.keyname,
           delegator_address: x.delegation.delegator_address,
-          delegation: formatToken(x.balance),
+          delegation: formatToken(x.balance, {}, decimal),
           reward: this.findReward(x.delegation.delegator_address, x.delegation.validator_address),
           // action: '',
         }

--- a/src/views/WalletDelegations.vue
+++ b/src/views/WalletDelegations.vue
@@ -120,7 +120,7 @@ export default {
   computed: {
     formatedDelegations() {
       const conf = this.$http.getSelectedConfig()
-      const decimal = conf.assets.exponent || '6'
+      const decimal = conf.assets[0].exponent || '6'
       return this.delegations.map(x => ({
         validator: {
           logo: x.chain.logo,
@@ -138,7 +138,7 @@ export default {
     groupedDelegations() {
       const group = {}
       const conf = this.$http.getSelectedConfig()
-      const decimal = conf.assets.exponent || '6'
+      const decimal = conf.assets[0].exponent || '6'
       this.delegations.forEach(x => {
         const d = {
           validator: {

--- a/src/views/components/OperationModal/components/Delegate.vue
+++ b/src/views/components/OperationModal/components/Delegate.vue
@@ -236,7 +236,7 @@ export default {
     },
     format(v) {
       const conf = this.$http.getSelectedConfig()
-      const decimal = conf.assets.exponent || '6'
+      const decimal = conf.assets[0].exponent || '6'
       return formatToken(v, this.IBCDenom, decimal)
     },
   },

--- a/src/views/components/OperationModal/components/Delegate.vue
+++ b/src/views/components/OperationModal/components/Delegate.vue
@@ -235,7 +235,9 @@ export default {
       return formatTokenDenom(this.token)
     },
     format(v) {
-      return formatToken(v, this.IBCDenom, 6)
+      const conf = this.$http.getSelectedConfig()
+      const decimal = conf.assets.exponent || '6'
+      return formatToken(v, this.IBCDenom, decimal)
     },
   },
 }

--- a/src/views/components/OperationModal/components/Redelegate.vue
+++ b/src/views/components/OperationModal/components/Redelegate.vue
@@ -179,8 +179,10 @@ export default {
       return options
     },
     tokenOptions() {
+      const conf = this.$http.getSelectedConfig()
+      const decimal = conf.assets.exponent || '6'
       if (!this.delegations) return []
-      return this.delegations.filter(x => x.delegation.validator_address === this.validatorAddress).map(x => ({ value: x.balance.denom, label: formatToken(x.balance) }))
+      return this.delegations.filter(x => x.delegation.validator_address === this.validatorAddress).map(x => ({ value: x.balance.denom, label: formatToken(x.balance, {}, decimal) }))
     },
     msg() {
       return [{

--- a/src/views/components/OperationModal/components/Redelegate.vue
+++ b/src/views/components/OperationModal/components/Redelegate.vue
@@ -180,7 +180,7 @@ export default {
     },
     tokenOptions() {
       const conf = this.$http.getSelectedConfig()
-      const decimal = conf.assets.exponent || '6'
+      const decimal = conf.assets[0].exponent || '6'
       if (!this.delegations) return []
       return this.delegations.filter(x => x.delegation.validator_address === this.validatorAddress).map(x => ({ value: x.balance.denom, label: formatToken(x.balance, {}, decimal) }))
     },


### PR DESCRIPTION
The options for delegation and redelegation in the "Delegation" area for the Dashboard or Wallet details, when clicked only represented the amount with 2 decimals.  Often this was rounding up and when a User chooses to redelegate if they enter in the amount shown can run into an issue where they cannot submit the transaction due to the share amount being incorrect.

The proposed fix I have submitted would change the following visual aspects:

All changes can be viewed on my fork, https://explorer.erialos.me

1. Dashboard
The dashboard will report the current wallet and its delegations.  I have changed the delegated amount to represent the chain's decimals as defined in the chain config.  This is to help the user have a better idea of their exact amount.

2. Wallet Account Detail
When viewing your wallet, the Delegation amount is now represented by the number of decimals defined in the chain config.

3. Wallet Delegations
The delegation amount shown is now shown with the number of decimals defined in the chain config.

4. Redelegate and Delegate buttons
When clicking on redelegate, often the correct balance was rounded up to the nearest 2 decimal places.  I have changed this to be what is defined in the chain config.
In other cases, the amount would be slightly more than the represented amount with 2 decimals. So when you redelegated or delegated, there would be a small amount of remaining dust to deal with.

Please let me know if some of the changes are not wanted and I can adjust the PR to your liking if needed.
Thank you!

