### PR TITLE
Breadcrumb navigation links

### DIFF
--- a/src/@core/layouts/components/AppBreadcrumb.vue
+++ b/src/@core/layouts/components/AppBreadcrumb.vue
@@ -31,7 +31,7 @@
                 {{ chainname }}
               </b-breadcrumb-item>
               <b-breadcrumb-item
-                v-for="item in $route.meta.breadcrumb"
+                v-for="item in breadcrumb"
                 :key="item.text"
                 :active="item.active"
                 :to="item.to"
@@ -74,6 +74,14 @@ export default {
   computed: {
     chainname() {
       return this.$store?.state?.chains?.selected?.chain_name
+    },
+    /**
+     * Invoke `route.meta.breadcrumb($route)` if breadcrumb is callable.
+     */
+    breadcrumb() {
+      const { breadcrumb } = this.$route.meta
+      const breadcrumbIsCallable = typeof breadcrumb === 'function'
+      return breadcrumbIsCallable ? breadcrumb(this.$route) : breadcrumb
     },
   },
 }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -249,16 +249,16 @@ const router = new VueRouter({
       component: () => import('@/views/StakingValidator.vue'),
       meta: {
         pageTitle: 'Staking Validator',
-        breadcrumb: [
+        breadcrumb: route => ([
           {
             text: 'Staking',
-            active: true,
+            to: `/${route.params.chain}/staking`,
           },
           {
             text: 'Validator',
             active: true,
           },
-        ],
+        ]),
       },
     },
     {
@@ -317,16 +317,16 @@ const router = new VueRouter({
       component: () => import('@/views/Block.vue'),
       meta: {
         pageTitle: 'Block',
-        breadcrumb: [
+        breadcrumb: route => ([
           {
             text: 'Blocks',
-            active: true,
+            to: `/${route.params.chain}/blocks`,
           },
           {
             text: 'Block',
             active: true,
           },
-        ],
+        ]),
       },
     },
     {


### PR DESCRIPTION
Make it possible to use `route.params` inside the breadcrumb. Use it to link to `/:chain/staking` and `/:chain/blocks`.
See how the breadcrumbs links are clickable now for staking:
![image](https://user-images.githubusercontent.com/24973/204916258-47d1f052-5933-4a9f-81f3-40786abb0c26.png)
And blocks:
![image](https://user-images.githubusercontent.com/24973/204916386-d9544789-f7cd-49f0-8758-c1faa501329f.png)
