### PR TITLE
fix(ticker): rm ticker for whitewhale, there is no coingecko ticker yet

### DIFF
--- a/src/chains/mainnet/whitewhale.json
+++ b/src/chains/mainnet/whitewhale.json
@@ -13,7 +13,7 @@
       "base": "uwhale",
       "symbol": "WHALE",
       "exponent": "6",
-      "coingecko_id": "whale",
+      "coingecko_id": "",
       "logo": "/logos/whale.png"
     }
   ]


### PR DESCRIPTION
Ticker is for an Eth based WHALE token, this just removes that.