### PR TITLE
added RPC used for Keplr

### DIFF
--- a/src/chains/mainnet/aura.json
+++ b/src/chains/mainnet/aura.json
@@ -3,6 +3,7 @@
     "coingecko": "aura-network",
     "api": ["https://lcd.aura.network"],
     "rpc": [
+        "https://rpc.aura.network:443",
         "https://snapshot-1.aura.network:443",
         "https://snapshot-2.aura.network:443"
     ],


### PR DESCRIPTION
Since adding a chain to keplr from the explorer uses the first RPC listed in the chain file, i've added the correct RPC that needs to be used for tx's