### PR TITLE
Update and rename omniflix.json to omniflixhub.json

### DIFF
--- a/chains/mainnet/omniflixhub.json
+++ b/chains/mainnet/omniflixhub.json
@@ -1,5 +1,5 @@
 {
-    "chain_name": "omniflix",
+    "chain_name": "omniflixhub",
     "coingecko": "",
     "api": ["https://api.omniflix.nodestake.top","https://omniflixhub-api.skynetvalidators.com"],
     "rpc": ["https://rpc.omniflix.nodestake.top"],


### PR DESCRIPTION
omniflixhub is the canonical name in the chain-registry