### PR TITLE
fix nolus image extension

### DIFF
--- a/chains/mainnet/nolus.json
+++ b/chains/mainnet/nolus.json
@@ -8,12 +8,12 @@
     "coin_type": "118",
     "min_tx_fee": "0",
     "addr_prefix": "nolus",
-    "logo": "/logos/nolus.png",
+    "logo": "/logos/nolus.svg",
     "assets": [{
         "base": "unls",
         "symbol": "NLS",
         "exponent": "6",
         "coingecko_id": "",
-        "logo": "/logos/nolus.png"
+        "logo": "/logos/nolus.svg"
     }]
 }


### PR DESCRIPTION
Nolus image didnt load as its an .svg and not .png

chain.json refferal was wrong