### PR TITLE
Improve bech32 regex

### DIFF
--- a/src/layouts/components/NavbarSearch.vue
+++ b/src/layouts/components/NavbarSearch.vue
@@ -31,7 +31,7 @@ function confirm() {
   }
   const height = /^\d+$/;
   const txhash = /^[A-Z\d]{64}$/;
-  const addr = /^[a-z]+1[a-z\d]{38,58}$/;
+  const addr = /^[a-z\d]+1[a-z\d]{38,58}$/;
 
   const current = blockStore?.current?.chainName || '';
   const routeParams = vueRouters?.currentRoute?.value;


### PR DESCRIPTION
This PR proposes an update to the regular expression used for parsing Bech32 addresses. Currently, there is an issue that prevents searching for Bech32 addresses in the explorer when they have a number in the prefix (HRP). The existing regex pattern:

```ts
const addr = /^[a-z]+1[a-z\d]{38,58}$/;
```

fails to correctly handle such addresses, and more specifically our chain's prefix, 'okp4' (https://github.com/okp4/okp4d protocol) is not recognized.

The PR proposes a new pattern which accommodates a broader range of characters in both the prefix and the data part of the Bech32 address, ensuring proper recognition and parsing of addresses with the okp4 prefix.

ex:

```js
→ /^[a-z]+1[a-z\d]{38,58}$/.test("okp41z5qcmx9frn2y92cjy3k62gzylkezkphdwrx3675mvug3fd9l26fsntq53t")
false

→ /^[\x21-\x7E]{1,83}1[023456789acdefghjklmnpqrstuvwxyz]{6,}$/.test("okp41z5qcmx9frn2y92cjy3k62gzylkezkphdwrx3675mvug3fd9l26fsntq53t")
true 
```

Thanks for your consideration!