### PR TITLE
Update hermit.json

### DIFF
--- a/chains/mainnet/hermit.json
+++ b/chains/mainnet/hermit.json
@@ -1,7 +1,7 @@
 
 {
     "chain_name": "hermit",
-    "api": ["https://api.hermit.network"], 
+    "api": ["https://rpc.hermit.network:1317"], 
     "rpc": ["https://rpc1.hermit.network","http://rpc.hermit.network:26657","https://rpc2.hermit.network"],
     "sdk_version": "0.45.4",
     "coin_type": "928",


### PR DESCRIPTION
Update the information on hermit.json. The error in filling in the original API link resulted in the hermit network not being able to read the information correctly on the Ping.Pub Dashboard. Please correct it now. For example: https://rpc.hermit.network:1317/cosmos/base/tendermint/v1beta1/node_info Can correctly obtain chain information instead of being blank.