### PR TITLE
Fix new text proposal (no messages) for 0.46+

### DIFF
--- a/src/libs/clients/v0.46.0.ts
+++ b/src/libs/clients/v0.46.0.ts
@@ -17,7 +17,7 @@ export const name = 'v0.46.7'
 
 function proposalAdapter(p: any): GovProposal {
     if(p) {
-        if(p.messages) p.content = p.messages[0].content || p.messages[0]
+        if(p.messages && p.messages.length >= 1) p.content = p.messages[0].content || p.messages[0]
         p.proposal_id = p.id
         p.final_tally_result = {
             yes: p.final_tally_result?.yes_count,


### PR DESCRIPTION
Tested this now on empowerchain testnet to see how it looks like, and noticed that the new text proposals failed. It is because it has no messages and an empty array is truth. Fixed with an extra check. Let me know if you have any concerns. Will test more.