### PR TITLE
feat: add i18n for proposal status on proposal page

### DIFF
--- a/src/modules/[chain]/gov/[proposal_id].vue
+++ b/src/modules/[chain]/gov/[proposal_id].vue
@@ -303,7 +303,7 @@ function pageload(p: number) {
               </div>
             </div>
             <div class="pl-5 text-sm">
-              {{ $t('gov.current_status') }}: {{ proposal.status }}
+              {{ $t('gov.current_status') }}: {{ $t(`gov.proposal_statuses.${proposal.status}`) }}
             </div>
           </div>
 

--- a/src/plugins/i18n/locales/en.json
+++ b/src/plugins/i18n/locales/en.json
@@ -133,6 +133,13 @@
     "vote_start_from": "Voting start from",
     "vote_end": "Voting end",
     "current_status": "Current Status",
+    "proposal_statuses": {
+      "PROPOSAL_STATUS_DEPOSIT_PERIOD": "Deposit period",
+      "PROPOSAL_STATUS_VOTING_PERIOD": "Voting period",
+      "PROPOSAL_STATUS_PASSED": "Passed",
+      "PROPOSAL_STATUS_REJECTED": "Rejected",
+      "PROPOSAL_STATUS_FAILED": "Failed"
+    },
     "upgrade_plan": "Upgrade Plan",
     "votes": "Votes"
   },


### PR DESCRIPTION
Okay so the proposal page displays raw proposal status, so I updated it.
Before:
<img width="1183" alt="изображение" src="https://github.com/ping-pub/explorer/assets/83376337/6e90b758-eeff-405e-a452-ee46c050891c">
After:
<img width="1178" alt="изображение" src="https://github.com/ping-pub/explorer/assets/83376337/414e2e47-a5aa-4cc0-8e8e-e3f3d06b7f75">

One of my concerns is that there's already i18n for proposal statuses, namely on a proposals list page, but it's made slightly different, so we can update it there as well, I guess. Additionally, I'm not a frontend guy so maybe there's a better way to do it, please let me know if so