### PR TITLE
Alternative approach to PR #519

### DIFF
--- a/src/stores/useBlockchain.ts
+++ b/src/stores/useBlockchain.ts
@@ -176,19 +176,18 @@ export const useBlockchain = defineStore('blockchain', {
       );
     },
     async setCurrent(name: string) {
-      // Ensure chains are loaded due to asynchronous calls.
-      if(this.dashboard.length === 0) {
-        await this.dashboard.initial();
+      // Get caps-correct chains from local storage.
+      const localChains: Array<string> = JSON.parse(localStorage.getItem("chains") || "[]");
+
+      // If chains are found in localStorage, then attempt to find the caps-correct chain name.
+      if(localChains.length > 0) {
+        name = localChains.find((x) => x.toLowerCase() === name.toLowerCase()) 
+          || name;
       }
 
-      // Find the case-sensitive name for the chainName, else simply use the parameter-value.
-      const caseSensitiveName = 
-        Object.keys(this.dashboard.chains).find((x) => x.toLowerCase() === name.toLowerCase()) 
-        || name;
-
       // Update chainName if needed
-      if (caseSensitiveName !== this.chainName) {
-        this.chainName = caseSensitiveName;
+      if (name !== this.chainName) {
+        this.chainName = name;
       }
     },
     supportModule(mod: string) {

--- a/src/stores/useDashboard.ts
+++ b/src/stores/useDashboard.ts
@@ -275,9 +275,9 @@ export const useDashboard = defineStore('dashboard', {
     },
   },
   actions: {
-    async initial() {
-      await this.loadingFromLocal();
-      // await this.loadingFromRegistry()
+    initial() {
+      this.loadingFromLocal();
+      // this.loadingFromRegistry()
     },
     loadingPrices() {
       const coinIds = [] as string[]
@@ -312,6 +312,7 @@ export const useDashboard = defineStore('dashboard', {
           });
           this.status = LoadingStatus.Loaded;
         });
+        localStorage.setItem("chains", JSON.stringify(Object.keys(this.chains)));
       }
     },
     async loadingFromLocal() {
@@ -327,6 +328,7 @@ export const useDashboard = defineStore('dashboard', {
       });
       this.setupDefault();
       this.status = LoadingStatus.Loaded;
+      localStorage.setItem("chains", JSON.stringify(Object.keys(this.chains)));
     },
     async loadLocalConfig(network: NetworkType) {
       const config: Record<string, ChainConfig> = {} 


### PR DESCRIPTION
## Please read the discord messages first before checking this out!

Hi!

So this is the alternative approach that I spoke of in Discord. It stores the names for all chains in `localStorage` and uses this in the `setCurrent(name)` function to case correct the chain instead of calling `await this.dashboard.initial()`.

The only caveat with this approach is that the very first load won't have a `chains` array stored in localStorage, so if we'd visit your site for the very first time by searching for e.g. https://ping.pub/genesisl1 it would return an empty page. Refreshing would find it since the localStorage would then be present.

You could also mix this approach with the other one: for instance if the chains object isn't in localStorage, you call `await this.dashboard.initial()` and use `this.dashboard.chains` instead of the now `localChains` variable.

But yeah that may perhaps again cause too much strain IF this actually strained the server!

I kinda hope the previous code wasn't the problem, but I had to give you an alternative in case it is playing a role in the current downtime!


ZEN