### PR TITLE
feat: add consensus prefix to config

### DIFF
--- a/src/libs/address.ts
+++ b/src/libs/address.ts
@@ -1,8 +1,6 @@
 import {
   fromBase64,
   fromBech32,
-  fromHex,
-  toBase64,
   toBech32,
   toHex,
 } from '@cosmjs/encoding';
@@ -10,13 +8,6 @@ import { Ripemd160, sha256 } from '@cosmjs/crypto';
 
 export function decodeAddress(address: string) {
   return fromBech32(address);
-}
-
-export function valoperToPrefix(valoper?: string) {
-  if (!valoper) return '';
-  const prefixIndex = valoper.indexOf('valoper');
-  if (prefixIndex === -1) return null;
-  return valoper.slice(0, prefixIndex);
 }
 
 export function operatorAddressToAccount(operAddress?: string) {
@@ -59,7 +50,7 @@ export function pubKeyToValcons(
     const pubkey = fromBase64(consensusPubkey.key);
     if (pubkey) {
       const addressData = sha256(pubkey).slice(0, 20);
-      return toBech32(`${prefix}valcons`, addressData);
+      return toBech32(prefix, addressData);
     }
   }
   return '';

--- a/src/modules/[chain]/staking/[validator].vue
+++ b/src/modules/[chain]/staking/[validator].vue
@@ -13,7 +13,6 @@ import {
   consensusPubkeyToHexAddress,
   operatorAddressToAccount,
   pubKeyToValcons,
-  valoperToPrefix,
 } from '@/libs';
 import { PageRequest, type Coin, type Delegation, type PaginatedDelegations, type PaginatedTxs, type Validator } from '@/types';
 import PaginationBar from '@/components/PaginationBar.vue';
@@ -127,13 +126,12 @@ onMounted(() => {
       identity.value = res.validator?.description?.identity || '';
       if (identity.value && !avatars.value[identity.value]) loadAvatar(identity.value);
 
-      const prefix = valoperToPrefix(v.value.operator_address) || '<Invalid>';
       addresses.value.hex = consensusPubkeyToHexAddress(
         v.value.consensus_pubkey
       );
       addresses.value.valCons = pubKeyToValcons(
         v.value.consensus_pubkey,
-        prefix
+        blockchain.current.bech32ConsensusPrefix,
       );
     });
     blockchain.rpc

--- a/src/stores/useDashboard.ts
+++ b/src/stores/useDashboard.ts
@@ -57,6 +57,7 @@ export interface ChainConfig {
   chainName: string;
   prettyName: string;
   bech32Prefix: string;
+  bech32ConsensusPrefix: string;
   chainId: string;
   coinType: string;
   assets: Asset[];
@@ -89,6 +90,7 @@ export interface ChainConfig {
 
 export interface LocalConfig {
   addr_prefix: string;
+  consensus_prefix?: string;
   alias: string;
   api: string[] | Endpoint[];
   provider_chain: {
@@ -153,6 +155,7 @@ export function fromLocal(lc: LocalConfig): ChainConfig {
     cosmosSdk: lc.sdk_version
   }
   conf.bech32Prefix = lc.addr_prefix;
+  conf.bech32ConsensusPrefix = lc.consensus_prefix ?? lc.addr_prefix + 'valcons';
   conf.chainName = lc.chain_name;
   conf.coinType = lc.coin_type;
   conf.prettyName = lc.registry_name || lc.chain_name;
@@ -177,6 +180,7 @@ export function fromDirectory(source: DirectoryChain): ChainConfig {
   const conf = {} as ChainConfig;
   (conf.assets = source.assets),
     (conf.bech32Prefix = source.bech32_prefix),
+    (conf.bech32ConsensusPrefix = source.bech32_prefix + 'valcons'),
     (conf.chainId = source.chain_id),
     (conf.chainName = source.chain_name),
     (conf.prettyName = source.pretty_name),


### PR DESCRIPTION
Fixes #527.

This adds a bech32 consensus prefix to config and uses it instead of assuming that Bech32ValidatorPrefix = Bech32Prefix + "valoper" and Bech32ConsensusPrefix = Bech32Prefix + "valcons".
For chain-registry configs there's no such field, so we assume the default prefixes.
For local configs we assume the default prefix unless it's specified explicitly in config.
Also removed the functions used previously for converting prefixes as they are no longer needed.