### PR TITLE
Fix commission rate formatting

### DIFF
--- a/src/components/ValidatorCommissionRate.vue
+++ b/src/components/ValidatorCommissionRate.vue
@@ -91,7 +91,7 @@ const chartConfig = computed(() => {
                             offsetY: -15,
                             fontWeight: 500,
                             fontSize: '2.125rem',
-                            formatter: (value: unknown) => `${rate.value}%`,
+                            formatter: (value: unknown) => `${rate.value.toFixed(0)}%`,
                             color: primaryText,
                         },
                         total: {
@@ -99,7 +99,7 @@ const chartConfig = computed(() => {
                             label: 'Commission Rate',
                             fontSize: '1rem',
                             color: secondaryText,
-                            formatter: () => `${rate.value}%`,
+                            formatter: () => `${rate.value.toFixed(0)}%`,
                         },
                     },
                 },
@@ -130,7 +130,7 @@ const chartConfig = computed(() => {
             <div class="flex items-center justify-center flex-wrap gap-x-3">
                 <div class="flex items-center gap-x-2">
                     <div class="bg-success w-[6px] h-[6px] rounded-full"></div>
-                    <span class="text-caption">Rate:{{ rate }}%</span>
+                    <span class="text-caption">Rate:{{ rate.toFixed(0) }}%</span>
                 </div>
                 <div class="flex items-center gap-x-2">
                     <div class="bg-success w-[6px] h-[6px] rounded-full opacity-60"></div>


### PR DESCRIPTION
Fixes #533.

Here's how the validator from the original issue looks like with the fix:
<img width="399" alt="image" src="https://github.com/ping-pub/explorer/assets/83376337/45a06fd6-dd72-41e1-a8e5-08dcd186b752">
