### PR TITLE
feat: libs: add Promise.resolve in `getGovProposalTally`

### DIFF
--- a/src/libs/client.ts
+++ b/src/libs/client.ts
@@ -162,13 +162,15 @@ export class CosmosRestClient extends BaseRestClient<RequestRegistry> {
   }
   async getGovProposalTally(proposal_id: string) {
     return this.request(this.registry.gov_proposals_tally, { proposal_id }, undefined, (source: any) => {
-      return {tally: {
+      return Promise.resolve({ tally: {
         yes: source.tally.yes || source.tally.yes_count,
         abstain: source.tally.abstain || source.tally.abstain_count,
         no: source.tally.no || source.tally.no_count,
         no_with_veto: source.tally.no_with_veto || source.tally.no_with_veto_count,
-      }};
-    });
+        },
+        });
+      }
+    );
   }
   async getGovProposalVotes(proposal_id: string, page?: PageRequest) {
     if(!page) page = new PageRequest()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,6 +2184,11 @@
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
 
+"@shikijs/core@1.0.0-beta.1":
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@shikijs/core/-/core-1.0.0-beta.1.tgz#40d21605cfc30c9d83bdc3c03414d478930ec30c"
+  integrity sha512-z3gdznaRj/DJSLQdR2Gdx6AB3e5+Il/kSGdLTGHI7HnalgPL15RbGgBSdLHW8rKAz4+dezAcTdnxm8z6YTu7nA==
+
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
@@ -6007,6 +6012,13 @@ shelljs@0.8.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+shiki@^1.0.0-beta.0:
+  version "1.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-1.0.0-beta.1.tgz#fbff19e1ba180e3093f274b00fd6578237d157bd"
+  integrity sha512-iq32WxjemJVlAHg5HjYoL1qCxGmvyh3Z8kr2E/gMTQdcxyXxTpMhahIC7myxFBapAk9o8QN8mxCpr4JT5rqpRQ==
+  dependencies:
+    "@shikijs/core" "1.0.0-beta.1"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
In the getGovProposalTally method, added `Promise.resolve` to the adapter function to ensure it returns a Promise. This resolves the TypeScript error related to the return type mismatch.