### PR TITLE
Fix IBC fetch from registry

### DIFF
--- a/src/modules/[chain]/ibc/connStore.ts
+++ b/src/modules/[chain]/ibc/connStore.ts
@@ -42,10 +42,14 @@ export const useIBCModule = defineStore('module-ibc', {
     fetchConnection(path: string) {
       const client = new ChainRegistryClient();
       client.fetchIBCPathInfo(path).then(res => {
-        const connId = res.chain_1.chain_name === this.chain.current?.prettyName || this.chain.chainName ?
-          res.chain_1.connection_id : res.chain_2.connection_id
-        this.registryConf = res
-        this.showConnection(connId)
+        const isFirstChain = res.chain_1.chain_name === this.chain.current?.prettyName || res.chain_1.chain_name === this.chain.chainName;
+
+        const connId = isFirstChain
+          ? res.chain_1.connection_id
+          : res.chain_2.connection_id;
+
+        this.registryConf = res;
+        this.showConnection(connId);
       })
     },
     showConnection(connId?: string | number) {


### PR DESCRIPTION
Fixes #531.

Basically, as I understood, `res.chain_1.chain_name === this.chain.current?.prettyName || this.chain.chainName` is always true if the chain is selected, which is pretty much not what's desired, right?