### PR TITLE
Fixes 24h changes formatting

### DIFF
--- a/src/stores/useDashboard.ts
+++ b/src/stores/useDashboard.ts
@@ -290,15 +290,15 @@ export const useDashboard = defineStore('dashboard', {
       keys.forEach(k => {
         if(this.chains[k]) this.chains[k].assets.forEach(a => {
           if(a.coingecko_id !== undefined && a.coingecko_id.length > 0) {
-            coinIds.push(a.coingecko_id)
+              coinIds.push(a.coingecko_id)
+            a.denom_units.forEach(u => {
+              this.coingecko[u.denom] = {
+                coinId: a.coingecko_id || '',
+                exponent: u.exponent,
+                symbol: a.symbol
+              }
+            })
           }
-          a.denom_units.forEach(u => {
-            this.coingecko[u.denom] = {
-              coinId: a.coingecko_id || '',
-              exponent: u.exponent,
-              symbol: a.symbol
-            }
-          })
         })
       })
 

--- a/src/stores/useDashboard.ts
+++ b/src/stores/useDashboard.ts
@@ -290,7 +290,7 @@ export const useDashboard = defineStore('dashboard', {
       keys.forEach(k => {
         if(this.chains[k]) this.chains[k].assets.forEach(a => {
           if(a.coingecko_id !== undefined && a.coingecko_id.length > 0) {
-              coinIds.push(a.coingecko_id)
+            coinIds.push(a.coingecko_id)
             a.denom_units.forEach(u => {
               this.coingecko[u.denom] = {
                 coinId: a.coingecko_id || '',
@@ -298,7 +298,7 @@ export const useDashboard = defineStore('dashboard', {
                 symbol: a.symbol
               }
             })
-          }
+          } 
         })
       })
 

--- a/src/stores/useDashboard.ts
+++ b/src/stores/useDashboard.ts
@@ -291,14 +291,14 @@ export const useDashboard = defineStore('dashboard', {
         if(this.chains[k]) this.chains[k].assets.forEach(a => {
           if(a.coingecko_id !== undefined && a.coingecko_id.length > 0) {
             coinIds.push(a.coingecko_id)
-            a.denom_units.forEach(u => {
-              this.coingecko[u.denom] = {
-                coinId: a.coingecko_id || '',
-                exponent: u.exponent,
-                symbol: a.symbol
-              }
-            })
-          } 
+          }
+          a.denom_units.forEach(u => {
+            this.coingecko[u.denom] = {
+              coinId: a.coingecko_id || '',
+              exponent: u.exponent,
+              symbol: a.symbol
+            }
+          })
         })
       })
 

--- a/src/stores/useFormatter.ts
+++ b/src/stores/useFormatter.ts
@@ -121,16 +121,15 @@ export const useFormatter = defineStore('formatter', {
         case denom.startsWith("a"): return 18
         case denom==='inj': return 18
       }
-      return 0
+      return this.exponentForDenom(denom)
     },
     tokenAmountNumber(token?: Coin) {
       if(!token || !token.denom) return 0
 
       // find the symbol
       const symbol = this.dashboard.coingecko[token.denom]?.symbol || token.denom 
-      // convert denomination to to symbol
-      const exponent =
-        this.dashboard.coingecko[symbol?.toLowerCase()]?.exponent || this.specialDenom(token.denom);
+      // convert denomination to symbol
+      const exponent = this.dashboard.coingecko[symbol?.toLowerCase()]?.exponent || this.specialDenom(token.denom);
       // caculate amount of symbol
       const amount = Number(token.amount) / (10 ** exponent)
       return amount
@@ -160,7 +159,20 @@ export const useFormatter = defineStore('formatter', {
       }
       return undefined
     },
+    exponentForDenom(denom: string) {
+      const asset: Asset | undefined = this.findGlobalAssetConfig(denom)
+      let exponent = 0;
+      if (asset) {
+        // find the max exponent for display
+        asset.denom_units.forEach((x) => {
+          if (x.exponent >= exponent) {
+            exponent = x.exponent;
+          }
+        });
+      }
 
+      return exponent;
+    },
     tokenDisplayDenom(denom?: string) {
       if (denom) {
         let asset: Asset | undefined;


### PR DESCRIPTION
Hi,

The `assets`-array for a chain wasn't being included in the `coingecko`-object when there was no `coingecko_id` set. This caused the exponent to show incorrectly formatted 24 hour changes on the Staking page. See an example of a chain that has a denom of 18, but gets treated as having 0: https://ping.pub/genesisL1/staking.

It should be fixed after this PR, but it might be better practice to name the object differently, since `coingecko` would assume the chain is available on CoinGecko.