### PR TITLE
Update TextElement.vue

### DIFF
--- a/src/components/dynamic/TextElement.vue
+++ b/src/components/dynamic/TextElement.vue
@@ -3,7 +3,7 @@ import { isBech32Address } from '@/libs/utils';
 import { useBlockchain, useFormatter } from '@/stores';
 import MdEditor from 'md-editor-v3';
 import { computed, onMounted, ref } from 'vue';
-import nameMatcha from '@leapwallet/name-matcha'
+import nameMatcha from '@leapwallet/name-matcha';
 import { fromBase64, toHex } from '@cosmjs/encoding';
 
 const chainStore = useBlockchain()


### PR DESCRIPTION
vue-router.mjs:3479 SyntaxError: The requested module '/node_modules/.vite/deps/@leapwallet_name-matcha.js?v=0b44e09c' does not provide an export named 'default' (at TextElement.vue:6:8)


@leapwallet/name-matcha does not export default export