### PR TITLE
fix(staking): correct APR computation formula

### DIFF
--- a/src/modules/[chain]/staking/[validator].vue
+++ b/src/modules/[chain]/staking/[validator].vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { parseCoins } from '@cosmjs/stargate';
 import {
+  useBankStore,
   useBlockchain,
+  useDistributionStore,
   useFormatter,
   useMintStore,
   useStakingStore,
@@ -64,12 +66,12 @@ blockchain.rpc.getTxsBySender(addresses.value.account).then((x) => {
 });
 
 const apr = computed(() => {
-  const rate = v.value.commission?.commission_rates.rate || 0;
+  const rate = Number(v.value.commission?.commission_rates.rate || 0);
   const inflation = useMintStore().inflation;
-  if (Number(inflation)) {
-    return format.percent((1 - Number(rate)) * Number(inflation));
-  }
-  return '-';
+  const communityTax = Number(useDistributionStore().params.community_tax);
+  const bondedRatio = Number(staking.pool.bonded_tokens) / Number(useBankStore().supply.amount);
+
+  return format.percent((1 - communityTax) * (1 - rate) * Number(inflation) / bondedRatio);
 });
 
 const selfRate = computed(() => {

--- a/src/stores/useBlockchain.ts
+++ b/src/stores/useBlockchain.ts
@@ -16,10 +16,11 @@ import { CosmosRestClient } from '@/libs/client';
 import {
   useBankStore,
   useBaseStore,
+  useDistributionStore,
   useGovStore,
   useMintStore,
   useStakingStore,
-  useWalletStore,
+  useWalletStore
 } from '.';
 import { useBlockModule } from '@/modules/[chain]/block/block';
 import { DEFAULT } from '@/libs';
@@ -151,6 +152,7 @@ export const useBlockchain = defineStore('blockchain', {
       useGovStore().initial();
       useMintStore().initial();
       useBlockModule().initial();
+      useDistributionStore().initial();
     },
 
     randomEndpoint(chainName: string) : Endpoint | undefined {

--- a/src/stores/useDistributionStore.ts
+++ b/src/stores/useDistributionStore.ts
@@ -3,7 +3,14 @@ import { useBlockchain } from './useBlockchain';
 
 export const useDistributionStore = defineStore('distributionStore', {
   state: () => {
-    return {};
+    return {
+      params: {} as {
+        community_tax: string;
+        base_proposer_reward: string;
+        bonus_proposer_reward: string;
+        withdraw_addr_enabled: boolean;
+      },
+    };
   },
   getters: {
     blockchain() {
@@ -11,6 +18,14 @@ export const useDistributionStore = defineStore('distributionStore', {
     },
   },
   actions: {
+    initial() {
+      this.fetchParams();
+    },
+    async fetchParams() {
+      const response = await this.blockchain.rpc?.getDistributionParams();
+      if (response?.params) this.params = response.params;
+      return this.params;
+    },
     async fetchCommunityPool() {
       return this.blockchain.rpc?.getDistributionCommunityPool();
     },


### PR DESCRIPTION
I noticed the APR calculation formula in the validator page may lack some precisions, this PR tries to improve it by bringing some missing elements in the computation.

## Details

Through this PR I propose to take into account in the calculation process two key elements:
- **Community tax**: A fixed rate of the rewards feeding the community pool, I think the concerned rewards should not be considered in the APR;
- **Bonded ratio**: The inflation is based on the total supply but staking rewards concerns only stake holders, I think the APR should care about that;

Here is the proposed formula:
```
(1 - $communityTax) * (1 - $commisionRate) * $inflation / $bondedRatio
```

Let me know what's your position about that, I'd be happy to discuss it.