### PR TITLE
[FIX] fix typo in pricemarket chart

### DIFF
--- a/src/components/charts/PriceMarketChart.vue
+++ b/src/components/charts/PriceMarketChart.vue
@@ -16,7 +16,7 @@ const kind = ref('price');
 const series = computed(() => {
     return [
         {
-            name: 'Price',
+            name: kind.value === 'price' ? 'Price' : 'Volume',
             data:
                 kind.value === 'price'
                     ? store.marketData.prices.map((item: any) => item[1])


### PR DESCRIPTION
when clicking the volume tab of the chat, hover tip remains Price, should be Volume