### PR TITLE
remove truncation of blockspeed to more accurately estimate block arrival

### DIFF
--- a/src/modules/[chain]/block/[height].vue
+++ b/src/modules/[chain]/block/[height].vue
@@ -38,7 +38,7 @@ const remainingBlocks = computed(() => {
 })
 
 const estimateTime = computed(() => {
-  const seconds = remainingBlocks.value * Number((store.blocktime / 1000).toFixed()) * 1000
+  const seconds = remainingBlocks.value * store.blocktime
   return seconds
 })
 

--- a/src/modules/[chain]/block/[height].vue
+++ b/src/modules/[chain]/block/[height].vue
@@ -38,7 +38,7 @@ const remainingBlocks = computed(() => {
 })
 
 const estimateTime = computed(() => {
-  const seconds = remainingBlocks.value * store.blocktime
+  const seconds = Number((remainingBlocks.value * store.blocktime).toFixed(2))
   return seconds
 })
 


### PR DESCRIPTION
We noticed that the estimation of future blocks is inaccurate which shows extremely for very low blocktimes. This change fixes the issue by removing unnecessary rounding.

The old rounding basically removed anything after the decimal point in terms of block speed. If the speed was 5.8 s/block, it would truncate it to 5 s/block. We are operating at ~1.5s, so the truncation to 1s caused a 30% error