### PR TITLE
Updating rest port to correctly configure api

### DIFF
--- a/chains/testnet/bfhevm.json
+++ b/chains/testnet/bfhevm.json
@@ -1,7 +1,7 @@
 {
     "chain_name": "bfhevm_777-1",
-    "api": ["https://rest-testnet-bfhevm.xyz:4431/swagger/#/"],
-    "rpc": ["https://rpc-bfhevm.xyz:8443/"],
+    "api": ["https://rest-testnet-bfhevm.xyz:443"],
+    "rpc": ["https://rpc-bfhevm.xyz:8443"],
     "coingecko": "",
     "snapshot_provider": "",
     "sdk_version": "0.45.7",


### PR DESCRIPTION
Hi Team,

Apologies for sending this request again but I am just trying to make the testnet.ping.pub/bfhevm work which wasn't working as I din't configure rest or api port to serve "/swagger" at "/"

updating rest port to correctly configure api and make it available at the explorer

Regards,

Monk