### PR TITLE
fix: class binding for reactive `kind` variable

### DIFF
--- a/src/components/charts/PriceMarketChart.vue
+++ b/src/components/charts/PriceMarketChart.vue
@@ -36,7 +36,7 @@ function changeChart(type: string) {
     <div class="tabs tabs-boxed bg-transparent justify-end">
         <a
             class="tab text-xs mr-2 text-gray-400 uppercase"
-            :class="{ 'tab-active': kind === 'price' }"
+            :class="{ 'tab-active': kind.value === 'price' }"
             @click="changeChart('price')"
         >
             Price


### PR DESCRIPTION
fixed the issue with class binding for the `kind` variable. Since `kind` is a `ref`, it needs to be accessed with `.value` to work correctly with class updates.