### PR TITLE
Fix xion inflation

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,5 @@
     "vite-plugin-pages": "^0.28.0",
     "vue-json-viewer": "3",
     "vue-tsc": "^1.0.12"
-  },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -75,5 +75,6 @@
     "vite-plugin-pages": "^0.28.0",
     "vue-json-viewer": "3",
     "vue-tsc": "^1.0.12"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/src/libs/api/customization/xion.ts
+++ b/src/libs/api/customization/xion.ts
@@ -66,7 +66,7 @@ export const requests: Partial<RequestRegistry> = {
     adapter,
   },
   mint_inflation: {
-    url: '/xion/mint/v1/inflation',
+    url: '/cosmos/mint/v1beta1/inflation',
     adapter: async (data: any): Promise<{ inflation: string }> => {
       try {
         const client = CosmosRestClient.newDefault(
@@ -99,6 +99,4 @@ export const requests: Partial<RequestRegistry> = {
       }
     },
   },
-  mint_params: { url: '/xion/mint/v1/params', adapter },
-  mint_annual_provisions: { url: '/xion/mint/v1beta1/annual_provisions', adapter }
 }


### PR DESCRIPTION
This pull request updates the `requests` object in `src/libs/api/customization/xion.ts` to align with the new API endpoints for the xion chain.  Xion has moved from using a custom mint module to using the mint module from cosmos sdk. The changes include replacing outdated URLs and removing no longer required request definitions.

### Updates to API endpoints:

* Updated the `mint_inflation` request URL to use the new endpoint `/cosmos/mint/v1beta1/inflation` instead of the deprecated `/xion/mint/v1/inflation`.

### Removal of unused requests:

* Removed `mint_params` and `mint_annual_provisions` requests from the `requests` object as they are no longer needed.