### PR TITLE
fix nameMatcha error in TextElement.vue

### DIFF
--- a/src/components/dynamic/TextElement.vue
+++ b/src/components/dynamic/TextElement.vue
@@ -3,7 +3,7 @@ import { isBech32Address } from '@/libs/utils';
 import { useBlockchain, useFormatter } from '@/stores';
 import MdEditor from 'md-editor-v3';
 import { computed, onMounted, ref } from 'vue';
-import nameMatcha from '@leapwallet/name-matcha'
+import { registry as nameMatcha } from '@leapwallet/name-matcha'
 import { fromBase64, toHex } from '@cosmjs/encoding';
 
 const chainStore = useBlockchain()


### PR DESCRIPTION
This pull request includes a small change to the import statement in the `TextElement.vue` file. The change updates the `nameMatcha` import to use destructuring and imports the `registry` member instead.