### PR TITLE
fix(account): show display amounts in Assets donut chart

### DIFF
--- a/src/modules/[chain]/account/[address].vue
+++ b/src/modules/[chain]/account/[address].vue
@@ -32,20 +32,20 @@ onMounted(() => {
 const totalAmountByCategory = computed(() => {
   let sumDel = 0;
   delegations.value?.forEach((x) => {
-    sumDel += Number(x.balance.amount);
+    sumDel += format.tokenAmountNumber(x.balance);
   });
   let sumRew = 0;
   rewards.value?.total?.forEach((x) => {
-    sumRew += Number(x.amount);
+    sumRew += format.tokenAmountNumber(x);
   });
   let sumBal = 0;
   balances.value?.forEach((x) => {
-    sumBal += Number(x.amount);
+    sumBal += format.tokenAmountNumber(x);
   });
   let sumUn = 0;
   unbonding.value?.forEach((x) => {
     x.entries?.forEach((y) => {
-      sumUn += Number(y.balance);
+      sumUn += format.tokenAmountNumber({ amount: y.balance, denom: stakingStore.params.bond_denom });
     });
   });
   return [sumBal, sumDel, sumRew, sumUn];
@@ -182,7 +182,7 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
                   {{ format.formatToken(balanceItem) }}
                 </div>
                 <div class="text-xs">
-                  {{ format.calculatePercent(balanceItem.amount, totalAmount) }}
+                  {{ format.calculatePercent(format.tokenAmountNumber(balanceItem), totalAmount) }}
                 </div>
               </div>
               <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary dark:invert mr-2">
@@ -201,7 +201,7 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
                   {{ format.formatToken(delegationItem?.balance) }}
                 </div>
                 <div class="text-xs">
-                  {{ format.calculatePercent(delegationItem?.balance?.amount, totalAmount) }}
+                  {{ format.calculatePercent(format.tokenAmountNumber(delegationItem?.balance), totalAmount) }}
                 </div>
               </div>
               <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary dark:invert mr-2">
@@ -220,7 +220,7 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
                   {{ format.formatToken(rewardItem) }}
                 </div>
                 <div class="text-xs">
-                  {{ format.calculatePercent(rewardItem.amount, totalAmount) }}
+                  {{ format.calculatePercent(format.tokenAmountNumber(rewardItem), totalAmount) }}
                 </div>
               </div>
               <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary dark:invert mr-2">
@@ -245,7 +245,15 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
                   }}
                 </div>
                 <div class="text-xs">
-                  {{ format.calculatePercent(unbondingTotal, totalAmount) }}
+                  {{
+                    format.calculatePercent(
+                      format.tokenAmountNumber({
+                        amount: String(unbondingTotal),
+                        denom: stakingStore.params.bond_denom,
+                      }),
+                      totalAmount
+                    )
+                  }}
                 </div>
               </div>
               <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary dark:invert mr-2">


### PR DESCRIPTION
Closes #668

## Summary

The Assets donut chart on `/{chain}/account/{address}` was being fed raw on-chain integer amounts (e.g. `uosmo`, `udec`, `satoshi`-level), so the chart center / hover tooltip showed numbers like `100000000` or `16601400` while the list right next to it correctly showed the formatted amounts (`1 OSMO`, `3 DEC`, etc).

This PR normalizes each balance / delegation / reward / unbonding entry to its display unit using the existing `format.tokenAmountNumber()` helper before summing, and updates the matching `calculatePercent(...)` calls in the right-side list so the per-row percentages stay consistent with the new total.

## What this PR does

- Donut series now sums **display-unit** amounts (`amount / 10^exponent`) instead of raw amounts, so the chart center and tooltip match the list next to them.
- `calculatePercent(...)` inputs in the right-side list are converted to the same unit so the percentages remain correct.
- File touched: `src/modules/[chain]/account/[address].vue` only.

## What this PR intentionally does NOT do

The underlying multi-token aggregation problem described in #668 — i.e. that summing raw amounts of different denominations is semantically meaningless even after exponent normalization — is **not** fully addressed here. The proper fix is to sum `format.tokenValueNumber(x)` (USD value) instead, matching how the `Total Value` line directly below the chart already works, and to update the donut center formatter in `src/components/charts/apexChartConfig.ts` (`parseInt(val, 10)`) to a currency-style format.

That change has wider implications (price availability per chain, formatter shared with other donut charts), so I kept this PR minimal and focused on removing the raw-amount display, which is a strict improvement on the current behavior even for multi-token accounts. Happy to follow up with the value-based version if you'd prefer that direction.

## Test plan

- [ ] Open an account page on a single-token chain — chart center / tooltip now show the display amount (e.g. `1`) instead of the raw integer (e.g. `100000000`).
- [ ] Open an account page with multiple denoms (e.g. the Osmosis account in #668) — center/tooltip no longer show the meaningless raw sum; right-side percentages still add up to ~100%.
- [ ] Spot-check that delegation / reward / unbonding categories still render correctly when present.