### PR TITLE
fix: resolve IBC token decimals in tokenAmountNumber

### DIFF
--- a/src/stores/useFormatter.ts
+++ b/src/stores/useFormatter.ts
@@ -125,6 +125,21 @@ export const useFormatter = defineStore('formatter', {
     tokenAmountNumber(token?: Coin) {
       if (!token || !token.denom) return 0;
 
+      // IBC denoms: resolve exponent from ibcMetadata (fetched lazily)
+      if (token.denom.startsWith('ibc/')) {
+        const ibcDenom = token.denom.replace('ibc/', '');
+        const conf = this.ibcMetadata[ibcDenom];
+        if (!conf) {
+          this.fetchDenomMetadata(ibcDenom);
+        } else {
+          let exponent = 0;
+          conf.denom_units.forEach((x) => {
+            if (x.exponent >= exponent) exponent = x.exponent;
+          });
+          return Number(token.amount) / 10 ** exponent;
+        }
+      }
+
       // find the symbol
       const symbol = this.dashboard.coingecko[token.denom]?.symbol || token.denom;
       // convert denomination to symbol


### PR DESCRIPTION
## Summary

Fixes #670.

`tokenAmountNumber` in `src/stores/useFormatter.ts` did not consult `ibcMetadata`, so for `ibc/<hash>` denoms it fell through to `specialDenom` → `exponentForDenom`, which returns `0` (no asset config matches `base === "ibc/<hash>"`). As a result the donut chart, per-row percentages, and the unbonding/delegation/reward sums in `src/modules/[chain]/account/[address].vue` rendered raw on-chain amounts for IBC balances.

#669 made the donut chart use `tokenAmountNumber` for series/percent inputs, which exposed this gap.

## Fix

Mirror the IBC-handling logic already present in `formatToken` / `tokenDisplayNumber`: if the denom starts with `ibc/`, resolve the exponent from `ibcMetadata` (fetching lazily on cache miss) before falling back to the existing coingecko/specialDenom path.

Factory denoms (e.g. `factory/.../allBTC`) are intentionally not changed — out of scope.

## Test plan

- [ ] Load an Osmosis account holding IBC balances, e.g. `/osmosis/account/osmo1dhsp650chvyn8vs70v8camcj3q7h7hxlcxl0ek`.
- [ ] Verify donut tooltip total is in human units (~`16.6` for the example account, not `5,001,112`).
- [ ] Verify per-row percentages for IBC denoms reflect display-unit shares of the portfolio.
- [ ] Confirm native denoms (`uosmo`, `uion`) and coingecko-mapped denoms still render correctly.
- [ ] Confirm the chart re-renders after the lazy `fetchDenomMetadata` populates `ibcMetadata` (first paint may show `0` for IBC rows until metadata arrives, same behavior as `formatToken`).