### PR TITLE
fix: refresh wallet balances when connection state changes

### DIFF
--- a/src/stores/useWalletStore.ts
+++ b/src/stores/useWalletStore.ts
@@ -109,7 +109,9 @@ export const useWalletStore = defineStore('walletStore', {
       this.$reset();
     },
     setConnectedWallet(value: WalletConnected) {
-      if (value) this.wallet = value;
+      if (!value) return;
+      this.wallet = value;
+      this.loadMyAsset();
     },
     suggestChain() {
       if (window.location.pathname === '/SIDE-Testnet') {


### PR DESCRIPTION
## Summary

- Fixes #673 — Balance / Staking / Reward / Unbonding cards on the chain dashboard stay at `0` after connecting a wallet, until the user navigates away and back.
- Trigger `loadMyAsset()` from `setConnectedWallet` so every consumer of the wallet store refreshes the moment the wallet changes (connect, reconnect, account switch).

## Root cause

`setConnectedWallet` only mutated `this.wallet`. The reactive getters (`balanceOfStakingToken`, `stakingAmount`, `rewardAmount`, `unbondingAmount`) all read from `this.balances` / `this.delegations` / `this.unbonding` / `this.rewards`, which are populated only by `loadMyAsset()`. That action was previously invoked only from `onMounted` and the chain-change subscriber in [src/modules/[chain]/index.vue](src/modules/[chain]/index.vue) — neither fires when the wallet changes mid-route. Re-mounting via navigation was the only way to re-run it, which is why the bug appeared to "fix itself" after a route change.

## Test plan

- [ ] Open a chain dashboard with no wallet connected. Click **Connect Wallet** → approve in Keplr → confirm Balance / Staking / Reward / Unbonding cards populate without a route change.
- [ ] Switch the active account inside Keplr and re-trigger connect → confirm the cards update to the new account's values.
- [ ] Disconnect → confirm cards reset to `0`.
- [ ] Visit `/wallet/portfolio` and `/wallet/accounts` after connecting → confirm no regression in those views.

🤖 Generated with [Claude Code](https://claude.com/claude-code)