### PR TITLE
feat: add Loading component and loading states

### DIFF
--- a/src/components/CardParameter.vue
+++ b/src/components/CardParameter.vue
@@ -2,10 +2,12 @@
 import type { PropType } from 'vue';
 import { useFormatter } from '@/stores';
 import { formatSeconds } from '@/libs/utils';
+import Loading from '@/components/Loading.vue';
 const props = defineProps({
   cardItem: {
     type: Object as PropType<{ title: string; items: Array<any> }>,
   },
+  loading: { type: Boolean, default: false },
 });
 
 const formatter = useFormatter();
@@ -35,10 +37,11 @@ function formatTitle(v: string) {
 <template>
   <div
     class="bg-base-100 px-4 pt-3 pb-4 rounded mt-5"
-    v-if="props.cardItem?.items && props.cardItem?.items?.length > 0"
+    v-if="props.loading || (props.cardItem?.items && props.cardItem?.items?.length > 0)"
   >
     <div class="text-base mb-3 text-main">{{ props.cardItem?.title }}</div>
-    <div class="grid grid-cols-2 md:!grid-cols-4 lg:!grid-cols-5 2xl:!grid-cols-6 gap-4">
+    <Loading v-if="props.loading" :bordered="false" />
+    <div v-else class="grid grid-cols-2 md:!grid-cols-4 lg:!grid-cols-5 2xl:!grid-cols-6 gap-4">
       <div v-for="(item, index) of props.cardItem?.items" :key="index" class="rounded-sm bg-active px-4 py-2">
         <div class="text-xs mb-2 text-secondary capitalize">{{ formatTitle(item?.subtitle) }}</div>
         <div class="text-base text-main">{{ calculateValue(item?.value) }}</div>

--- a/src/components/Loading.vue
+++ b/src/components/Loading.vue
@@ -1,0 +1,19 @@
+<script lang="ts" setup>
+defineProps({
+  height: { type: String, default: '72px' },
+  size: { type: String, default: 'md' },
+  text: { type: String, default: 'Loading ...' },
+  bordered: { type: Boolean, default: true },
+});
+</script>
+
+<template>
+  <div
+    class="flex justify-center items-center w-full gap-3"
+    :class="{ 'bg-base-100 rounded shadow': bordered }"
+    :style="{ height }"
+  >
+    <span class="loading loading-spinner text-primary" :class="`loading-${size}`"></span>
+    <span class="text-center">{{ text }}</span>
+  </div>
+</template>

--- a/src/modules/[chain]/block/[height].vue
+++ b/src/modules/[chain]/block/[height].vue
@@ -1,8 +1,9 @@
 <script lang="ts" setup>
-import { onMounted, ref, watchEffect } from 'vue';
+import { onMounted, ref } from 'vue';
 import { Icon } from '@iconify/vue';
 import TxsElement from '@/components/dynamic/TxsElement.vue';
 import DynamicComponent from '@/components/dynamic/DynamicComponent.vue';
+import Loading from '@/components/Loading.vue';
 import { computed } from '@vue/reactivity';
 import { onBeforeRouteUpdate } from 'vue-router';
 import { useBaseStore, useFormatter } from '@/stores';
@@ -15,21 +16,16 @@ const store = useBaseStore();
 const format = useFormatter();
 const current = ref({} as Block);
 const target = ref(Number(props.height || 0));
+const loading = ref(true);
 
 const height = computed(() => {
   return Number(current.value.block?.header?.height || props.height || 0);
 });
 
-const isFutureBlock = computed({
-  get: () => {
-    const latest = store.latest?.block?.header.height;
-    const isFuture = latest ? target.value > Number(latest) : true;
-    if (!isFuture && !current.value.block_id) store.fetchBlock(target.value).then((x) => (current.value = x));
-    return isFuture;
-  },
-  set: (val) => {
-    console.log(val);
-  },
+const isFutureBlock = computed(() => {
+  const latest = store.latest?.block?.header.height;
+  if (!latest) return false;
+  return target.value > Number(latest);
 });
 
 const remainingBlocks = computed(() => {
@@ -50,19 +46,43 @@ const edit = ref(false);
 const newHeight = ref(props.height);
 function updateTarget() {
   target.value = Number(newHeight.value);
-  console.log(target.value);
+  loadBlock(target.value);
 }
+
+async function loadBlock(h: number | string) {
+  loading.value = true;
+  try {
+    if (!store.latest?.block?.header?.height) {
+      await store.fetchLatest();
+    }
+    const latest = store.latest?.block?.header?.height;
+    if (latest && Number(h) <= Number(latest)) {
+      current.value = await store.fetchBlock(h);
+    } else {
+      current.value = {} as Block;
+    }
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(() => {
+  loadBlock(target.value);
+});
 
 onBeforeRouteUpdate(async (to, from, next) => {
   if (from.path !== to.path) {
-    store.fetchBlock(String(to.params.height)).then((x) => (current.value = x));
-    next();
+    target.value = Number(to.params.height);
+    current.value = {} as Block;
+    loadBlock(target.value);
   }
+  next();
 });
 </script>
 <template>
   <div>
-    <div v-if="isFutureBlock" class="text-center">
+    <Loading v-if="loading" />
+    <div v-else-if="isFutureBlock" class="text-center">
       <div v-if="remainingBlocks > 0">
         <div class="text-primary font-bold text-lg my-10">#{{ target }}</div>
         <Countdown :time="estimateTime" css="md:!text-5xl font-sans md:mx-5" />

--- a/src/modules/[chain]/ibc/connection/[connection_id].vue
+++ b/src/modules/[chain]/ibc/connection/[connection_id].vue
@@ -13,6 +13,7 @@ import { computed, onMounted } from 'vue';
 import { ref } from 'vue';
 import { useIBCModule } from '../connStore';
 import PaginationBar from '@/components/PaginationBar.vue';
+import Loading from '@/components/Loading.vue';
 import { Icon } from '@iconify/vue';
 
 const props = defineProps(['chain', 'connection_id']);
@@ -23,6 +24,8 @@ const ibcStore = useIBCModule();
 const conn = ref({} as Connection);
 const clientState = ref({} as { client_id: string; client_state: ClientState });
 const channels = ref([] as Channel[]);
+const clientStateLoaded = ref(false);
+const channelsLoaded = ref(false);
 
 const connId = computed(() => {
   return props.connection_id || 0;
@@ -41,12 +44,18 @@ onMounted(() => {
     chainStore.rpc.getIBCConnectionsById(connId.value).then((x) => {
       conn.value = x.connection;
     });
-    chainStore.rpc.getIBCConnectionsClientState(connId.value).then((x) => {
-      clientState.value = x.identified_client_state;
-    });
-    chainStore.rpc.getIBCConnectionsChannels(connId.value).then((x) => {
-      channels.value = x.channels;
-    });
+    chainStore.rpc
+      .getIBCConnectionsClientState(connId.value)
+      .then((x) => {
+        clientState.value = x.identified_client_state;
+      })
+      .finally(() => (clientStateLoaded.value = true));
+    chainStore.rpc
+      .getIBCConnectionsChannels(connId.value)
+      .then((x) => {
+        channels.value = x.channels;
+      })
+      .finally(() => (channelsLoaded.value = true));
   }
 });
 
@@ -154,7 +163,8 @@ function color(v: string) {
           clientState.client_state?.['@type']
         }}</span>
       </h2>
-      <div class="overflow-x-auto grid grid-cols-1 md:grid-cols-2 gap-4">
+      <Loading v-if="!clientStateLoaded" :bordered="false" />
+      <div v-else class="overflow-x-auto grid grid-cols-1 md:grid-cols-2 gap-4">
         <table class="table table-sm capitalize">
           <thead class="bg-base-200">
             <tr>
@@ -237,7 +247,8 @@ function color(v: string) {
     </div>
     <div class="bg-base-100 px-4 pt-3 pb-4 rounded mb-4 shadow overflow-hidden">
       <h2 class="card-title">{{ $t('ibc.channels') }}</h2>
-      <div class="overflow-auto">
+      <Loading v-if="!channelsLoaded" :bordered="false" />
+      <div v-else class="overflow-auto">
         <table class="table w-full mt-4">
           <thead>
             <tr>

--- a/src/modules/[chain]/index.vue
+++ b/src/modules/[chain]/index.vue
@@ -3,7 +3,8 @@ import MdEditor from 'md-editor-v3';
 import PriceMarketChart from '@/components/charts/PriceMarketChart.vue';
 
 import { Icon } from '@iconify/vue';
-import { useBlockchain, useFormatter, useTxDialog, useWalletStore, useStakingStore, useParamStore } from '@/stores';
+import { useBlockchain, useFormatter, useTxDialog, useWalletStore, useStakingStore, useParamStore, useGovStore } from '@/stores';
+import { LoadingStatus } from '@/stores/useDashboard';
 import { onMounted, ref } from 'vue';
 import { useIndexModule, colorMap, tickerUrl } from './indexStore';
 import { computed } from '@vue/reactivity';
@@ -11,6 +12,7 @@ import { computed } from '@vue/reactivity';
 import CardStatisticsVertical from '@/components/CardStatisticsVertical.vue';
 import ProposalListItem from '@/components/ProposalListItem.vue';
 import ArrayObjectElement from '@/components/dynamic/ArrayObjectElement.vue';
+import Loading from '@/components/Loading.vue';
 
 const props = defineProps(['chain']);
 
@@ -21,9 +23,17 @@ const format = useFormatter();
 const dialog = useTxDialog();
 const stakingStore = useStakingStore();
 const paramStore = useParamStore();
+const govStore = useGovStore();
 const coinInfo = computed(() => {
   return store.coinInfo;
 });
+const isAppVersionLoading = computed(
+  () => !Array.isArray(paramStore.appVersion?.items) || paramStore.appVersion.items.length === 0
+);
+const isNodeVersionLoading = computed(
+  () => !Array.isArray(paramStore.nodeVersion?.items) || paramStore.nodeVersion.items.length === 0
+);
+const isProposalsLoading = computed(() => govStore.loading['2'] !== LoadingStatus.Loaded);
 
 onMounted(() => {
   store.loadDashboard();
@@ -328,15 +338,18 @@ const amount = computed({
       <div class="px-4 pt-4 pb-2 text-lg font-semibold text-main">
         {{ $t('index.active_proposals') }}
       </div>
-      <div class="px-4 pb-4">
-        <ProposalListItem :proposals="store?.proposals" />
-      </div>
-      <div
-        class="pb-8 text-center"
-        v-if="store.proposals?.proposals?.length === 0"
-      >
-        {{ $t('index.no_active_proposals') }}
-      </div>
+      <Loading v-if="isProposalsLoading" :bordered="false" />
+      <template v-else>
+        <div class="px-4 pb-4">
+          <ProposalListItem :proposals="store?.proposals" />
+        </div>
+        <div
+          class="pb-8 text-center"
+          v-if="store.proposals?.proposals?.length === 0"
+        >
+          {{ $t('index.no_active_proposals') }}
+        </div>
+      </template>
     </div>
 
     <div class="bg-base-100 rounded mt-4 shadow">
@@ -471,7 +484,9 @@ const amount = computed({
         {{ $t('index.app_versions') }}
       </div>
       <!-- Application Version -->
+      <Loading v-if="isAppVersionLoading" :bordered="false" />
       <ArrayObjectElement
+        v-else
         :value="paramStore.appVersion?.items"
         :thead="false"
       />
@@ -482,7 +497,8 @@ const amount = computed({
       <div class="px-4 pt-4 pb-2 text-lg font-semibold text-main">
         {{ $t('index.node_info') }}
       </div>
-      <ArrayObjectElement :value="paramStore.nodeVersion?.items" :thead="false" />
+      <Loading v-if="isNodeVersionLoading" :bordered="false" />
+      <ArrayObjectElement v-else :value="paramStore.nodeVersion?.items" :thead="false" />
       <div class="h-4"></div>
     </div>
   </div>

--- a/src/modules/[chain]/params/index.vue
+++ b/src/modules/[chain]/params/index.vue
@@ -3,19 +3,33 @@ import { useParamStore } from '@/stores';
 import { ref, onMounted } from 'vue';
 import CardParameter from '@/components/CardParameter.vue';
 import ArrayObjectElement from '@/components/dynamic/ArrayObjectElement.vue';
+import Loading from '@/components/Loading.vue';
 const store = useParamStore();
 const chain = ref(store.chain);
+
+const chainLoading = ref(true);
+const stakingLoading = ref(true);
+const govLoading = ref(true);
+const distributionLoading = ref(true);
+const slashingLoading = ref(true);
+const abciLoading = ref(true);
+
 onMounted(() => {
-  // fetch the data
-  store.initial();
+  store.handleBaseBlockLatest().finally(() => (chainLoading.value = false));
+  store.handleStakingParams().finally(() => (stakingLoading.value = false));
+  store.handleGovernanceParams().finally(() => (govLoading.value = false));
+  store.handleDistributionParams().finally(() => (distributionLoading.value = false));
+  store.handleSlashingParams().finally(() => (slashingLoading.value = false));
+  store.handleAbciInfo().finally(() => (abciLoading.value = false));
 });
 </script>
 <template>
   <div class="overflow-hidden">
     <!-- Chain ID -->
     <div class="bg-base-100 px-4 pt-3 pb-4 rounded">
-      <div class="text-base mb-3 text-main">{{ chain.title }}</div>
-      <div class="grid grid-cols-2 md:!grid-cols-4 lg:!grid-cols-5 2xl:!grid-cols-6 gap-4">
+      <div class="text-base mb-3 text-main">{{ chain.title || 'Chain ID' }}</div>
+      <Loading v-if="chainLoading" :bordered="false" />
+      <div v-else class="grid grid-cols-2 md:!grid-cols-4 lg:!grid-cols-5 2xl:!grid-cols-6 gap-4">
         <div v-for="(item, index) of chain.items" :key="index" class="rounded-sm bg-active px-4 py-2">
           <div class="text-xs mb-2 text-secondary">{{ item.subtitle }}</div>
           <div class="text-base text-main">{{ item.value }}</div>
@@ -25,23 +39,25 @@ onMounted(() => {
     <!-- minting Parameters  -->
     <CardParameter :cardItem="store.mint" />
     <!-- Staking Parameters  -->
-    <CardParameter :cardItem="store.staking" />
+    <CardParameter :cardItem="store.staking" :loading="stakingLoading" />
     <!-- Governance Parameters -->
-    <CardParameter :cardItem="store.gov" />
+    <CardParameter :cardItem="store.gov" :loading="govLoading" />
     <!-- Distribution Parameters -->
-    <CardParameter :cardItem="store.distribution" />
+    <CardParameter :cardItem="store.distribution" :loading="distributionLoading" />
     <!-- Slashing Parameters -->
-    <CardParameter :cardItem="store.slashing" />
+    <CardParameter :cardItem="store.slashing" :loading="slashingLoading" />
     <!-- Application Version -->
     <div class="bg-base-100 px-4 pt-3 pb-4 rounded-sm mt-6">
       <div class="text-base mb-3 text-main">{{ store.appVersion?.title }}</div>
-      <ArrayObjectElement :value="store.appVersion?.items" :thead="false" />
+      <Loading v-if="abciLoading" :bordered="false" />
+      <ArrayObjectElement v-else :value="store.appVersion?.items" :thead="false" />
     </div>
 
     <!-- Node Information -->
     <div class="bg-base-100 px-4 pt-3 pb-4 rounded-sm mt-6">
       <div class="text-base mb-3 text-main">{{ store.nodeVersion?.title }}</div>
-      <ArrayObjectElement :value="store.nodeVersion?.items" :thead="false" />
+      <Loading v-if="abciLoading" :bordered="false" />
+      <ArrayObjectElement v-else :value="store.nodeVersion?.items" :thead="false" />
     </div>
   </div>
 </template>

--- a/src/modules/[chain]/supply/index.vue
+++ b/src/modules/[chain]/supply/index.vue
@@ -10,12 +10,14 @@ import {
 import { onMounted } from 'vue';
 import type { Asset } from '@/types/chaindata';
 import PaginationBar from '@/components/PaginationBar.vue';
+import Loading from '@/components/Loading.vue';
 const props = defineProps(['chain']);
 
 const format = useFormatter();
 const chainStore = useBlockchain();
 
 const list = ref([] as { denom: string; amount: string; base: string; info: string; logo: string | undefined }[]);
+const loading = ref(true);
 
 const pageRequest = ref(new PageRequest());
 const pageResponse = ref({} as Pagination);
@@ -54,23 +56,27 @@ async function mergeDenomMetadata(denom: string, denomsMetadatas: DenomMetadata[
 
 function pageload(p: number) {
   pageRequest.value.setPage(p);
-  chainStore.rpc.getBankDenomMetadata().then(async (denomsMetaResponse) => {
-    const bankSupplyResponse = await chainStore.rpc.getBankSupply(pageRequest.value);
-    list.value = await Promise.all(
-      bankSupplyResponse.supply.map(async (coin: Coin) => {
-        const asset = await mergeDenomMetadata(coin.denom, denomsMetaResponse.metadatas);
-        const denom = asset?.symbol || coin.denom;
-        return {
-          denom: denom.split('/')[denom.split('/').length - 1].toUpperCase(),
-          amount: format.tokenAmountNumber({ amount: coin.amount, denom: denom }).toString(),
-          base: asset.base || coin.denom,
-          info: asset.display || coin.denom,
-          logo: asset?.logo_URIs?.svg || asset?.logo_URIs?.png || '/logo.svg',
-        };
-      })
-    );
-    pageResponse.value = bankSupplyResponse.pagination;
-  });
+  loading.value = true;
+  chainStore.rpc
+    .getBankDenomMetadata()
+    .then(async (denomsMetaResponse) => {
+      const bankSupplyResponse = await chainStore.rpc.getBankSupply(pageRequest.value);
+      list.value = await Promise.all(
+        bankSupplyResponse.supply.map(async (coin: Coin) => {
+          const asset = await mergeDenomMetadata(coin.denom, denomsMetaResponse.metadatas);
+          const denom = asset?.symbol || coin.denom;
+          return {
+            denom: denom.split('/')[denom.split('/').length - 1].toUpperCase(),
+            amount: format.tokenAmountNumber({ amount: coin.amount, denom: denom }).toString(),
+            base: asset.base || coin.denom,
+            info: asset.display || coin.denom,
+            logo: asset?.logo_URIs?.svg || asset?.logo_URIs?.png || '/logo.svg',
+          };
+        })
+      );
+      pageResponse.value = bankSupplyResponse.pagination;
+    })
+    .finally(() => (loading.value = false));
 }
 </script>
 <template>
@@ -85,17 +91,21 @@ function pageload(p: number) {
           <td>Base</td>
         </tr>
       </thead>
-      <tr v-for="item in list" class="hover">
-        <td>
-          <img v-if="item.logo" :src="item.logo" class="w-7 h-7" />
-        </td>
-        <td>{{ item.denom }}</td>
-        <td>{{ item.amount }}</td>
-        <td>{{ item.info }}</td>
-        <td>{{ item.base }}</td>
-      </tr>
+      <tbody v-if="!loading">
+        <tr v-for="item in list" class="hover">
+          <td>
+            <img v-if="item.logo" :src="item.logo" class="w-7 h-7" />
+          </td>
+          <td>{{ item.denom }}</td>
+          <td>{{ item.amount }}</td>
+          <td>{{ item.info }}</td>
+          <td>{{ item.base }}</td>
+        </tr>
+      </tbody>
     </table>
+    <Loading v-if="loading" :bordered="false" />
     <PaginationBar
+      v-else
       :limit="pageRequest.limit"
       :total="pageResponse.total"
       :callback="pageload"

--- a/src/stores/useParamsStore.ts
+++ b/src/stores/useParamsStore.ts
@@ -154,17 +154,20 @@ export const useParamStore = defineStore('paramstore', {
       if (excludes && excludes.indexOf('governance') > -1) {
         return;
       }
-      Promise.all([this.getGovParamsVoting(), this.getGovParamsDeposit(), this.getGovParamsTally()]).then((resArr) => {
-        const govParams = {
-          ...resArr[0]?.voting_params,
-          ...resArr[1]?.deposit_params,
-          ...resArr[2]?.tally_params,
-        };
-        this.gov.items = Object.entries(govParams).map(([key, value]) => ({
-          subtitle: key,
-          value: value,
-        }));
-      });
+      const resArr = await Promise.all([
+        this.getGovParamsVoting(),
+        this.getGovParamsDeposit(),
+        this.getGovParamsTally(),
+      ]);
+      const govParams = {
+        ...resArr[0]?.voting_params,
+        ...resArr[1]?.deposit_params,
+        ...resArr[2]?.tally_params,
+      };
+      this.gov.items = Object.entries(govParams).map(([key, value]) => ({
+        subtitle: key,
+        value: value,
+      }));
     },
     async handleAbciInfo() {
       const res = await this.fetchAbciInfo();


### PR DESCRIPTION
## Summary

Adds a reusable `<Loading>` component and wires it into pages that previously rendered with empty data while async fetches were in flight. The goal is to give users a clear visual signal that data is being fetched, rather than a flash of empty cards.

### Changes

- **`src/components/Loading.vue`** (new): centered spinner + text inside an optional `bg-base-100` card. Props: `height`, `size`, `text`, `bordered`. Use `:bordered=\"false\"` to embed inside an existing card that already has its own title and background.
- **Block detail (`/<chain>/block/:height`)**: replaces the side-effect-in-computed pattern (where `isFutureBlock` was triggering `fetchBlock`) with a proper `onMounted` lifecycle hook and explicit `loading` state. Also ensures `store.latest` is loaded before deciding whether to treat a height as a future block, so the user no longer sees empty "Block Header" / "Transactions" / "Last Commit" cards on first paint.
- **Dashboard (`/<chain>`)**: Active Proposals, Application Version, and Node Information now show a loading row inside their cards while keeping titles visible. The proposals loading state is sourced from the existing `useGovStore().loading['2']` LoadingStatus tracking.
- **IBC Connection detail (`/<chain>/ibc/connection/:id`)**: top connection header (chain IDs, state, counterparty) stays visible; IBC Client and Channels sections show loading inside their cards while their async RPC calls are in flight.
- **Supply (`/<chain>/supply`)**: table headers stay visible, body is replaced with loading row during initial fetch and during page changes.
- **Parameters (`/<chain>/params`)**: per-section loading for Chain ID, Staking, Governance, Distribution, Slashing, Application Version, and Node Information. Each section is awaited independently so loading reflects only that section.
- **`CardParameter`**: accepts a new optional `loading` prop. When set, the card still renders (title visible) and shows the loading component instead of the value grid.
- **Bug fix in `useParamsStore.handleGovernanceParams`**: the `Promise.all` for voting/deposit/tally params was previously not awaited, so the action resolved before `gov.items` was populated. This made `.finally()`-based loading tracking fire too early. Now awaited correctly.

## Test plan

- [ ] Hard refresh `/<chain>/block/<height>` — should show a single loading card, then the populated block data (no empty cards flash)
- [ ] Hard refresh `/<chain>` — Active Proposals, Application Version, and Node Information sections show titles + loading until data arrives
- [ ] Visit an IBC connection detail page — connection header is visible immediately; IBC Client and Channels sections show loading until data arrives
- [ ] Visit `/<chain>/supply` and click pagination — table headers stay visible, loading row appears during fetch
- [ ] Visit `/<chain>/params` — each section independently shows loading and resolves to data
- [ ] Visit a chain with governance excluded — Governance Parameters card finishes loading and stays hidden (since `items.length === 0`)