### PR TITLE
Fix: Prevent block polling interval memory leak

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,50 @@
 <script setup lang="ts">
 import { themeChange } from 'theme-change';
-import { onMounted } from 'vue';
+import { onMounted, onUnmounted, ref } from 'vue';
 import TxDialog from './components/TxDialog.vue';
+import { useBaseStore } from '@/stores';
+
+const REFRESH_INTERVAL = import.meta.env.VITE_REFRESH_INTERVAL || 6000;
+
+const blockStore = useBaseStore();
+const requestCounter = ref(0);
+let pollingTimer: ReturnType<typeof setInterval> | null = null;
+
+function startPolling() {
+  if (pollingTimer !== null) return;
+  pollingTimer = setInterval(() => {
+    if (requestCounter.value >= 5) return;
+    requestCounter.value += 1;
+    blockStore.fetchLatest().finally(() => {
+      requestCounter.value -= 1;
+    });
+  }, REFRESH_INTERVAL);
+}
+
+function stopPolling() {
+  if (pollingTimer !== null) {
+    clearInterval(pollingTimer);
+    pollingTimer = null;
+  }
+}
+
+function handleVisibilityChange() {
+  if (document.hidden) {
+    stopPolling();
+  } else {
+    startPolling();
+  }
+}
 
 onMounted(() => {
   themeChange(false);
+  startPolling();
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+});
+
+onUnmounted(() => {
+  stopPolling();
+  document.removeEventListener('visibilitychange', handleVisibilityChange);
 });
 </script>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,11 @@
 import App from '@/App.vue';
 import i18n from '@/plugins/i18n';
 import '@/style.css';
-import { createApp, ref } from 'vue';
+import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import LazyLoad from 'lazy-load-vue3';
 
 import router from './router';
-import { useBaseStore } from '@/stores';
 
 // Create vue app
 const app = createApp(App);
@@ -19,15 +18,4 @@ app.use(LazyLoad, { component: true });
 // Mount vue app
 app.mount('#app');
 
-const REFRESH_INTERVAL = import.meta.env.VITE_REFRESH_INTERVAL || 6000; // 6 seconds
 
-// fetch latest block every 6s
-const blockStore = useBaseStore();
-const requestCounter = ref(0);
-setInterval(() => {
-  requestCounter.value += 1;
-  if (requestCounter.value < 5) {
-    // max allowed request
-    blockStore.fetchLatest().finally(() => (requestCounter.value -= 1));
-  }
-}, REFRESH_INTERVAL);

--- a/src/modules/[chain]/consensus/index.vue
+++ b/src/modules/[chain]/consensus/index.vue
@@ -20,6 +20,7 @@ let height = ref('');
 let round = ref('');
 let step = ref('');
 let timer = null as any;
+let loading = false;
 let updatetime = ref(new Date());
 let positions = ref([]);
 let validatorsData = ref([] as any);
@@ -36,6 +37,7 @@ onMounted(async () => {
 });
 onUnmounted(() => {
   clearTime();
+  loading = false;
 });
 
 function clearTime() {
@@ -80,15 +82,21 @@ function color(i: number, txt: string) {
   return txt === 'nil-Vote' ? 'gray-700' : 'success';
 }
 async function onChange() {
+  if (loading) return;
+  loading = true;
   httpstatus.value = 200;
   httpStatusText.value = '';
   roundState.value = {};
   clearTime();
-  await fetchPosition();
-  update();
-  timer = setInterval(() => {
+  try {
+    await fetchPosition();
     update();
-  }, Math.round(baseStore.blocktime / 2));
+    timer = setInterval(() => {
+      update();
+    }, Math.round(baseStore.blocktime / 2));
+  } finally {
+    loading = false;
+  }
 }
 
 async function fetchPosition() {


### PR DESCRIPTION
- Move polling setInterval from main.ts module scope into App.vue lifecycle hooks for proper cleanup on unmount
- Pause polling when tab is hidden (visibilitychange), resume on focus
- Fix concurrent request counter that could increment unboundedly on skipped ticks, permanently blocking all future fetches
- Add re-entry guard (loading flag) and finally block to consensus page onChange to prevent interval leak during rapid clicks