### PR TITLE
Add Limonata Testnet (limonata_10777-1)

### DIFF
--- a/chains/testnet/limonata-testnet.json
+++ b/chains/testnet/limonata-testnet.json
@@ -1,0 +1,24 @@
+{
+  "chain_name": "limonata-testnet",
+  "api": [
+    "https://rest.limonata.xyz"
+  ],
+  "rpc": [
+    "https://cosmos-rpc.limonata.xyz"
+  ],
+  "snapshot_provider": "",
+  "sdk_version": "0.54.3",
+  "coin_type": "60",
+  "min_tx_fee": "20000000",
+  "addr_prefix": "cosmos",
+  "logo": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/limonatatestnet/images/limonatatestnet.png",
+  "assets": [
+    {
+      "base": "aLIMO",
+      "symbol": "LIMO",
+      "exponent": "18",
+      "coingecko_id": "",
+      "logo": "https://raw.githubusercontent.com/cosmos/chain-registry/master/testnets/limonatatestnet/images/limonatatestnet.png"
+    }
+  ]
+}


### PR DESCRIPTION
Adds the Limonata Testnet, a Cosmos SDK + cosmos/evm Layer 1 (EVM chain ID 10777).

- **Chain ID:** `limonata_10777-1`
- **RPC:** https://cosmos-rpc.limonata.xyz
- **REST/API:** https://rest.limonata.xyz
- **SDK:** v0.54.3 · **coin type:** 60 (ethsecp256k1) · **prefix:** `cosmos`
- **Token:** LIMO (`aLIMO`, 18 decimals)
- Already listed in cosmos/chain-registry: https://github.com/cosmos/chain-registry/tree/master/testnets/limonatatestnet

Endpoints are live and CORS-enabled. Thanks for maintaining ping.pub!