### PR TITLE
perf(ads): preconnect + preload Slise embed so banners render as the page loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Warm up the Slise ad origin and start fetching the embed script in
+         parallel with the app bundle, so banners can render as the page loads
+         instead of after the ad component mounts. -->
+    <link rel="preconnect" href="https://v1.slise.xyz" crossorigin />
+    <link rel="dns-prefetch" href="https://v1.slise.xyz" />
+    <link rel="preload" href="https://v1.slise.xyz/scripts/embed.js" as="script" />
     <title>Ping Dashboard - Cosmos Blockchain Explorer And Web Wallet</title>
     <meta
       name="description"

--- a/src/components/ad/AdBanner.vue
+++ b/src/components/ad/AdBanner.vue
@@ -21,6 +21,8 @@ declare global {
   }
 }
 
+const SLISE_EMBED_SRC = 'https://v1.slise.xyz/scripts/embed.js';
+
 const props = defineProps({
   slot: {
     type: String,
@@ -81,21 +83,27 @@ onMounted(() => {
     observer.observe(containerRef.value);
   }
 
-  // Load script only once
-  if (!document.querySelector('script[src="https://v1.slise.xyz/scripts/embed.js"]')) {
-    const script = document.createElement('script');
-    script.src = 'https://v1.slise.xyz/scripts/embed.js';
-    script.async = true;
-    document.head.appendChild(script);
-  }
-
-  // Initialize ad queue
+  // Queue this slot for Slise.
   window.adsbyslise = window.adsbyslise || [];
   window.adsbyslise.push({ slot: props.slot });
-  
-  // Sync if available
-  if (typeof window.adsbyslisesync === 'function') {
-    window.adsbyslisesync();
+
+  // Fill the slot as soon as Slise's embed script is ready. Waiting for the
+  // script's `load` event (instead of a one-shot check) means the very first
+  // banner fills the moment the script arrives, rather than only on Slise's
+  // internal 1s location poll.
+  const sync = () => window.adsbyslisesync?.();
+  const existing = document.querySelector(`script[src="${SLISE_EMBED_SRC}"]`);
+
+  if (window.adsbyslisesync) {
+    sync();
+  } else if (existing) {
+    existing.addEventListener('load', sync, { once: true });
+  } else {
+    const script = document.createElement('script');
+    script.src = SLISE_EMBED_SRC;
+    script.async = true;
+    script.addEventListener('load', sync, { once: true });
+    document.head.appendChild(script);
   }
 });
 


### PR DESCRIPTION
## Problem

The Slise ad banner is blank for roughly a second after the page loads. The
cause is that the Slise embed script is only injected inside `AdBanner`'s
`onMounted`, i.e. **after** the app bundle has downloaded, parsed, and mounted
the ad component — and it's requested over a cold connection with no resource
hints.

Measured on the live site (Performance API, homepage, fast connection):

| Event | Time from navigation start |
|---|---|
| `embed.js` **requested** | **~1013 ms** |
| `embed.js` finished loading | ~2022 ms |
| ad request `POST /target/v1/native` | ~2078 ms |
| creative iframe painted | **~2767 ms** |

So the ad script isn't even *requested* until ~1 s in, and nothing about the
ad load overlaps the app boot.

## Changes

**1. `index.html` — warm the Slise origin and preload the embed script**

```html
<link rel="preconnect" href="https://v1.slise.xyz" crossorigin />
<link rel="dns-prefetch" href="https://v1.slise.xyz" />
<link rel="preload" href="https://v1.slise.xyz/scripts/embed.js" as="script" />
```

This starts the ~21 KB `embed.js` download in parallel with the app bundle
(instead of ~1 s later) and warms DNS/TLS. `embed.js` is already allow-listed
in the existing CSP, so no CSP change is needed. The component still *executes*
the script only when an `AdBanner` mounts — the preload just makes the bytes
ready in advance, so no ad code runs on pages that don't render an ad.

**2. `AdBanner.vue` — fill the slot as soon as the script is ready**

The previous code did a one-shot `typeof window.adsbyslisesync === 'function'`
check immediately after appending the `async` script. On the first banner the
function isn't defined yet (the script is still loading), so the sync was
silently skipped and the first ad only filled once Slise's script finished and
ran its own auto-sync. This now waits for the script's `load` event, so the
first banner fills the moment the script is ready rather than depending on
Slise's internal 1-second `location` poll.

## Verification

Built this branch and served the static output; the preload takes effect:

- `embed.js` `initiatorType` is now **`link`** (fetched by the preload, not the
  component), and its request **start moves from ~1013 ms → ~14 ms** after
  navigation — it now loads in parallel with the app bundle.

Type-check (`vue-tsc --noEmit`) and `vite build` both pass. The diff is two
files, no dependency or API changes.

## Notes

Happy to also add a small loading skeleton inside the reserved ad box, or wire
distinct `data-ad-slot` values per placement (today every placement uses the
default `desktop` slot, so co-located banners share one slot) if you'd like —
kept this PR minimal and focused on the load-timing fix.
