### PR TITLE
perf: preconnect + preload Slise embed so ad banners render as the pa…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,9 @@
     <meta charset="UTF-8" />
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://v1.slise.xyz" crossorigin />
+    <link rel="dns-prefetch" href="https://v1.slise.xyz" />
+    <link rel="preload" href="https://v1.slise.xyz/scripts/embed.js" as="script" />
     <title>Ping Dashboard - Cosmos Blockchain Explorer And Web Wallet</title>
     <meta
       name="description"

--- a/src/components/ad/AdBanner.vue
+++ b/src/components/ad/AdBanner.vue
@@ -21,6 +21,8 @@ declare global {
   }
 }
 
+const SLISE_EMBED_SRC = 'https://v1.slise.xyz/scripts/embed.js';
+
 const props = defineProps({
   slot: {
     type: String,
@@ -81,21 +83,22 @@ onMounted(() => {
     observer.observe(containerRef.value);
   }
 
-  // Load script only once
-  if (!document.querySelector('script[src="https://v1.slise.xyz/scripts/embed.js"]')) {
-    const script = document.createElement('script');
-    script.src = 'https://v1.slise.xyz/scripts/embed.js';
-    script.async = true;
-    document.head.appendChild(script);
-  }
-
-  // Initialize ad queue
   window.adsbyslise = window.adsbyslise || [];
   window.adsbyslise.push({ slot: props.slot });
-  
-  // Sync if available
-  if (typeof window.adsbyslisesync === 'function') {
-    window.adsbyslisesync();
+
+  const sync = () => window.adsbyslisesync?.();
+  const existing = document.querySelector(`script[src="${SLISE_EMBED_SRC}"]`);
+
+  if (window.adsbyslisesync) {
+    sync();
+  } else if (existing) {
+    existing.addEventListener('load', sync, { once: true });
+  } else {
+    const script = document.createElement('script');
+    script.src = SLISE_EMBED_SRC;
+    script.async = true;
+    script.addEventListener('load', sync, { once: true });
+    document.head.appendChild(script);
   }
 });
 


### PR DESCRIPTION
# perf: preconnect + preload Slise embed so ad banners render as the page loads

## Problem

The Slise ad banner stays blank for roughly a second after the page loads. The
embed script is only injected inside `AdBanner`'s `onMounted` — after the app
bundle downloads, parses, and mounts the ad component — and it's requested over
a cold connection with no resource hints, so nothing about the ad load overlaps
the app boot.

## Changes

**`index.html`** — `preconnect`/`dns-prefetch` the Slise origin and `preload`
`embed.js`, so the ~21 KB script downloads in parallel with the app bundle
instead of ~1 s later. `embed.js` is already allow-listed in the existing CSP,
so no CSP change is needed, and the script still only *executes* when an
`AdBanner` mounts — the preload just makes the bytes ready in advance.

**`AdBanner.vue`** — fill the slot on the script's `load` event instead of a
one-shot `typeof window.adsbyslisesync === 'function'` check. On the first
banner that function isn't defined yet (the async script is still loading), so
the previous code silently skipped the sync and the first ad only filled once
Slise's script finished and ran its own auto-sync. Waiting for `load` fills the
first banner the moment the script is ready.

## Result

Measured on a local build: `embed.js`'s request start moves from ~1013 ms to
~14 ms after navigation (now fetched by the preload), so the banner creative
can paint about a second sooner. `yarn build` (type-check + build) passes; the
diff is two files with no dependency or API changes.