### PR TITLE
perf: keep Slise banner mounted across navigation + gapless per-page …

### DIFF
--- a/src/components/ad/AdBanner.vue
+++ b/src/components/ad/AdBanner.vue
@@ -2,6 +2,7 @@
   <!-- Ad container with required attributes -->
   <div ref="containerRef" class="flex w-full justify-center overflow-hidden" :style="containerStyle">
     <ins
+      ref="insRef"
       class="adsbyslise"
       :style="adStyle"
       :data-ad-slot="slot"
@@ -12,7 +13,8 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useRoute } from 'vue-router';
 
 declare global {
   interface Window {
@@ -47,7 +49,9 @@ const props = defineProps({
 });
 
 const containerRef = ref<HTMLElement | null>(null);
+const insRef = ref<HTMLElement | null>(null);
 const scale = ref(1);
+const route = useRoute();
 
 function toPixels(value: string) {
   const parsed = Number.parseFloat(value);
@@ -100,6 +104,12 @@ onMounted(() => {
     script.addEventListener('load', sync, { once: true });
     document.head.appendChild(script);
   }
+});
+
+watch(() => route.fullPath, () => {
+  if (!insRef.value || typeof window.adsbyslisesync !== 'function') return;
+  insRef.value.removeAttribute('data-ad-loaded');
+  window.adsbyslisesync();
 });
 
 onBeforeUnmount(() => {

--- a/src/layouts/components/DefaultLayout.vue
+++ b/src/layouts/components/DefaultLayout.vue
@@ -320,12 +320,10 @@ const show_ad = computed(() => {
             >
           </div>
         </div>
+        <AdBanner v-if="show_ad" />
         <RouterView v-slot="{ Component }">
           <Transition mode="out-in">
-            <div>
-              <AdBanner v-if="show_ad" />
-              <Component :is="Component" />
-            </div>
+            <Component :is="Component" />
           </Transition>
         </RouterView>
       </div>


### PR DESCRIPTION
## Keep Slise banner mounted across navigation + gapless per-page refresh

### Background

PR #686 fixed the **cold-load** delay (preconnect + preload of `embed.js`, and
syncing on the script `load` event instead of a one-shot `typeof` check). After
that merged you noted:

> "it's better now, but there still a delayed refresh during page switching."

This PR fixes that remaining navigation delay.

### What was wrong (measured on production ping.pub)

`<AdBanner>` lived **inside** `<RouterView><Transition mode="out-in">`, so it was
**destroyed and recreated on every client-side navigation**. On each remount
Slise blanks the `<ins>` and refetches a creative, so the banner went blank and
only repainted once the (often heavy) destination page finished mounting.

Timing `click → banner visible` across 37 real navigations:

| scenario                        | median | max     |
|---------------------------------|--------|---------|
| chain routes (cosmos, 7 routes) | ~500ms | ~2665ms |
| wallet routes (warm)            | ~150ms | ~193ms  |

The delay tracked **page weight** — the blank banner competed with the route
component for the main thread, so `/cosmos/uptime` was consistently ~2.5s blank.
It was **not** a queue leak (`window.adsbyslise` stays length 1) and **not** a
CSS transition.

### The fix

1. **Persist the banner.** `<AdBanner>` is now a sibling *above* `<RouterView>`
   in `DefaultLayout.vue`, so it mounts once and stays mounted across
   navigations — never destroyed, so it never blanks.

2. **Refresh gaplessly per navigation.** `AdBanner` watches `route.fullPath`.
   On each navigation it removes `data-ad-loaded` from its `<ins>` **without
   clearing the existing creative**, then calls `window.adsbyslisesync()`. Slise
   refetches and swaps the new creative in **only when ready**, so the previous
   ad stays on screen the whole time — no blank gap.

   (Re-calling `adsbyslisesync()` on an `<ins>` that still has `data-ad-loaded`
   does nothing — Slise skips loaded slots — which is why the flag must be
   dropped first. Verified against the live embed.)

### Result

- **No blank gap on navigation** — old creative stays visible while the next
  loads in the background.
- **A fresh creative (impression) per page view** is preserved.
- Behaviour is now independent of destination-page weight.

### Trade-off / rollback

Keeps a **per-navigation ad refresh** (every page view = fresh impression). If
that is not wanted, delete the `route.fullPath` watcher in `AdBanner.vue` and
the banner stays a single persistent ad — still gap-free, just no rotation.