### PR TITLE
fix(blocks): treat a malformed blocks/latest response as a failed poll

### DIFF
--- a/src/stores/useBaseStore.ts
+++ b/src/stores/useBaseStore.ts
@@ -80,11 +80,19 @@ export const useBaseStore = defineStore('baseStore', {
       if (!this.hasRpc) return this.latest;
       try {
         const latest = await this.blockchain.rpc?.getBaseBlockLatest();
-        // A malformed 200 (an error body, a rate-limit page) would otherwise be
-        // stored as `latest`; its missing chain_id then trips the reset below and
-        // wipes earliest/recents, resetting the average block time to the 1000ms
+        // A malformed 200 - an error body, a rate-limit page, a truncated
+        // response - would otherwise be stored as `latest`. The chain_id
+        // comparison below would then see undefined against the previous chain,
+        // wipe earliest/recents and reset the average block time to the 1000ms
         // placeholder. Treat it as a failed poll instead.
-        if (!latest?.block?.header?.height) throw new Error('malformed blocks/latest payload');
+        //
+        // chain_id is checked as well as height: it is specifically the missing
+        // chain_id that trips that reset, so a partial payload carrying a height
+        // but no chain_id would otherwise still cause the state loss this guards.
+        const header = latest?.block?.header;
+        if (!header?.height || !header?.chain_id) {
+          throw new Error('malformed blocks/latest payload');
+        }
         this.latest = latest;
         this.connected = true;
       } catch (error) {

--- a/src/stores/useBaseStore.ts
+++ b/src/stores/useBaseStore.ts
@@ -79,7 +79,13 @@ export const useBaseStore = defineStore('baseStore', {
     async fetchLatest() {
       if (!this.hasRpc) return this.latest;
       try {
-        this.latest = await this.blockchain.rpc?.getBaseBlockLatest();
+        const latest = await this.blockchain.rpc?.getBaseBlockLatest();
+        // A malformed 200 (an error body, a rate-limit page) would otherwise be
+        // stored as `latest`; its missing chain_id then trips the reset below and
+        // wipes earliest/recents, resetting the average block time to the 1000ms
+        // placeholder. Treat it as a failed poll instead.
+        if (!latest?.block?.header?.height) throw new Error('malformed blocks/latest payload');
+        this.latest = latest;
         this.connected = true;
       } catch (error) {
         console.error('Error fetching latest block:', error);


### PR DESCRIPTION
fetchLatest trusts the response shape. An endpoint that answers 200 with something other than a block - an error body, a rate-limit page, a proxy interstitial - is stored as `latest`. Its missing chain_id then fails this check:

  if (!this.earliest || this.earliest?...chain_id != this.latest?...chain_id) {
    this.earliest = this.latest;
    this.recents = [];
  }

That branch exists to detect a chain switch, but a junk payload trips it identically, so `earliest` and `recents` are wiped. The visible effect is the average block time snapping back to the 1000ms placeholder and the recent-blocks list emptying, intermittently, with nothing surfaced to the user.

Observed against a flaky endpoint: the average block time read 1679 -> 6117 ->
1000 -> 3844 ms against a true 4060 ms, with recents dropping 4 -> 1. With the payload validated it converged to 3957 ms and neither value reset, while a third of responses were still being rejected as malformed.