### PR TITLE
fix(env): VITE_* env vars are strings, not numbers or booleans

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,10 +1,12 @@
 /// <reference types="vite/client" />
 
 declare module '@personaxyz/ad-sdk';
+// Vite injects env vars as strings whatever the .env file looks like. Declaring
+// them as number/boolean hides bugs such as `"false"` being truthy.
 interface ImportMetaEnv {
-    readonly VITE_REFRESH_INTERVAL?: number,
-    readonly VITE_FETCH_ALL_BLOCKS?: boolean,
-    readonly VITE_RECENT_BLOCK_LIMIT?: number,
+    readonly VITE_REFRESH_INTERVAL?: string,
+    readonly VITE_FETCH_ALL_BLOCKS?: string,
+    readonly VITE_RECENT_BLOCK_LIMIT?: string,
     readonly VITE_COINGECKO_URL?: string,
     readonly VITE_GITHUB_API_URL?: string,
     readonly VITE_PINGPUB_API_URL?: string,

--- a/src/App.vue
+++ b/src/App.vue
@@ -4,7 +4,7 @@ import { onMounted, onUnmounted, ref } from 'vue';
 import TxDialog from './components/TxDialog.vue';
 import { useBaseStore } from '@/stores';
 
-const REFRESH_INTERVAL = import.meta.env.VITE_REFRESH_INTERVAL || 6000;
+const REFRESH_INTERVAL = Number(import.meta.env.VITE_REFRESH_INTERVAL) || 6000;
 
 const blockStore = useBaseStore();
 const requestCounter = ref(0);

--- a/src/stores/useBaseStore.ts
+++ b/src/stores/useBaseStore.ts
@@ -6,8 +6,9 @@ import type { Block } from '@/types';
 import { hashTx } from '@/libs';
 import { fromBase64 } from '@cosmjs/encoding';
 
-const FETCH_ALL_BLOCKS = import.meta.env.VITE_FETCH_ALL_BLOCKS || false;
-const RECENT_BLOCKS_LIMIT = import.meta.env.VITE_RECENT_BLOCK_LIMIT || 50;
+// `"false"` is a truthy string, so compare explicitly.
+const FETCH_ALL_BLOCKS = import.meta.env.VITE_FETCH_ALL_BLOCKS === 'true';
+const RECENT_BLOCKS_LIMIT = Number(import.meta.env.VITE_RECENT_BLOCK_LIMIT) || 50;
 
 export const useBaseStore = defineStore('baseStore', {
   state: () => {


### PR DESCRIPTION
Vite injects env vars as strings regardless of what the .env file contains, but env.d.ts declared three of them as number/boolean. That mistyping hid a real bug:

  const FETCH_ALL_BLOCKS = import.meta.env.VITE_FETCH_ALL_BLOCKS || false;

`VITE_FETCH_ALL_BLOCKS=false` yields the string "false", which is truthy, so the documented way to turn the feature off in .env.example silently turns it on - and it then fetches every intermediate block, which is exactly the rate-limiting the flag exists to avoid.

Corrects the declared types, compares explicitly against 'true', and coerces the two numeric vars so they reach setInterval and slice as numbers.