### PR TITLE
Pr/theme customisation

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -80,3 +80,54 @@ server {
 }
 ```
 3. config your blockchain in [./chains/mainnet]()
+
+# Theming
+
+Colours live in the daisyUI themes in `tailwind.config.js`. Editing them re-themes
+the app; no component changes are needed.
+
+```js
+// tailwind.config.js
+daisyui: {
+  themes: [
+    {
+      light: {
+        ...require('daisyui/src/theming/themes')['[data-theme=light]'],
+        primary: '#0f766e',
+      },
+    },
+    {
+      dark: {
+        ...require('daisyui/src/theming/themes')['[data-theme=dark]'],
+        primary: '#2dd4bf',
+        'base-100': '#0b1220', // cards, sidebar, header
+        'base-200': '#111a2e', // page bands, table headers
+      },
+    },
+  ],
+},
+```
+
+Spreading the stock theme first means you only list what you want to change.
+
+The tokens you will reach for most:
+
+| token | used for |
+| --- | --- |
+| `primary` | active nav, buttons, links, chart accent |
+| `base-100` | cards, sidebar, header |
+| `base-200` / `base-300` | page bands, table headers, hover |
+| `base-content` | default text colour |
+| `info` `success` `warning` `error` | status text, badges, vote bars |
+
+Full list: https://daisyui.com/docs/colors/
+
+Tailwind reads the config at startup, so restart the dev server after editing.
+
+Two caveats:
+
+- A component that hardcodes a colour (`text-gray-400`, `bg-green-500`, ...) will
+  not follow the theme. Those are gradually being moved onto tokens.
+- `@ping-pub/widget` injects its own daisyUI build at runtime, which would
+  otherwise override these values. `postcss.config.js` re-emits the theme at a
+  higher specificity so the app's config wins - keep that plugin if you fork.

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,31 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
+// @ping-pub/widget bundles its own Tailwind + daisyUI build and injects it into
+// the document at runtime. That stylesheet re-declares [data-theme=light] and
+// [data-theme=dark], and because it lands after the app's stylesheet it wins on
+// equal specificity - so a project that customises `daisyui.themes` silently
+// gets the widget's values back in the browser.
+//
+// This duplicates each daisyUI theme rule with an `html` prefix, raising it from
+// specificity (0,1,0) to (0,1,1) so the app's own theme wins. Values are copied
+// verbatim, so there is no visual change wherever the two already agree. The
+// original rule is kept, which preserves daisyUI's element-level theming
+// (`<div data-theme="...">`).
+const raiseThemeSpecificity = () => ({
+  postcssPlugin: 'raise-theme-specificity',
+  OnceExit(root) {
+    const clones = [];
+    root.walkRules((rule) => {
+      if (rule.__themeSpecificityRaised) return;
+      const targets = rule.selectors.filter((s) => /^\[data-theme=/.test(s.trim()));
+      if (!targets.length) return;
+      const clone = rule.clone({ selectors: targets.map((s) => `html${s.trim()}`) });
+      clone.__themeSpecificityRaised = true;
+      clones.push([rule, clone]);
+    });
+    clones.forEach(([rule, clone]) => rule.after(clone));
   },
+});
+raiseThemeSpecificity.postcss = true;
+
+module.exports = {
+  plugins: [require('tailwindcss'), raiseThemeSpecificity(), require('autoprefixer')],
 };

--- a/src/components/dynamic/TextElement.vue
+++ b/src/components/dynamic/TextElement.vue
@@ -142,7 +142,7 @@ const isConvertable = computed(() => {
     margin-bottom: 1rem;
   }
   a {
-    color: #666cff !important;
+    color: hsl(var(--p)) !important;
   }
   .h1 > a,
   .h2 > a,

--- a/src/components/dynamic/TxsElement.vue
+++ b/src/components/dynamic/TxsElement.vue
@@ -47,7 +47,7 @@ const chain = useBlockchain();
           <td>{{ item.injected }}</td>
           <td>
             <span v-if="item.injected === 'Injected'">{{ item.hash }}</span>
-            <RouterLink v-else :to="`/${chain.chainName}/tx/${item.hash}`" class="text-primary dark:invert">{{
+            <RouterLink v-else :to="`/${chain.chainName}/tx/${item.hash}`" class="text-primary">{{
               item.hash
             }}</RouterLink>
           </td>

--- a/src/modules/[chain]/account/[address].vue
+++ b/src/modules/[chain]/account/[address].vue
@@ -185,7 +185,7 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
                   {{ format.calculatePercent(format.tokenAmountNumber(balanceItem), totalAmount) }}
                 </div>
               </div>
-              <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary dark:invert mr-2">
+              <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary mr-2">
                 <span class="inset-x-0 inset-y-0 opacity-10 absolute bg-primary dark:invert text-sm"></span>
                 ${{ format.tokenValue(balanceItem) }}
               </div>
@@ -204,7 +204,7 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
                   {{ format.calculatePercent(format.tokenAmountNumber(delegationItem?.balance), totalAmount) }}
                 </div>
               </div>
-              <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary dark:invert mr-2">
+              <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary mr-2">
                 <span class="inset-x-0 inset-y-0 opacity-10 absolute bg-primary dark:invert text-sm"></span>
                 ${{ format.tokenValue(delegationItem?.balance) }}
               </div>
@@ -223,7 +223,7 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
                   {{ format.calculatePercent(format.tokenAmountNumber(rewardItem), totalAmount) }}
                 </div>
               </div>
-              <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary dark:invert mr-2">
+              <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary mr-2">
                 <span class="inset-x-0 inset-y-0 opacity-10 absolute bg-primary dark:invert text-sm"></span>${{
                   format.tokenValue(rewardItem)
                 }}
@@ -256,7 +256,7 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
                   }}
                 </div>
               </div>
-              <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary dark:invert mr-2">
+              <div class="text-xs truncate relative py-1 px-3 rounded-full w-fit text-primary mr-2">
                 <span class="inset-x-0 inset-y-0 opacity-10 absolute bg-primary dark:invert"></span>
                 ${{
                   format.tokenValue({
@@ -450,14 +450,14 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
               <td class="text-sm py-3">
                 <RouterLink
                   :to="`/${chain}/block/${v.height}`"
-                  class="text-primary dark:invert"
+                  class="text-primary"
                   >{{ v.height }}</RouterLink
                 >
               </td>
               <td class="truncate py-3" style="max-width: 200px">
                 <RouterLink
                   :to="`/${chain}/tx/${v.txhash}`"
-                  class="text-primary dark:invert"
+                  class="text-primary"
                 >
                   {{ v.txhash }}
                 </RouterLink>
@@ -502,14 +502,14 @@ function mapAmount(events: { type: string; attributes: { key: string; value: str
               <td class="text-sm py-3">
                 <RouterLink
                   :to="`/${chain}/block/${v.height}`"
-                  class="text-primary dark:invert"
+                  class="text-primary"
                   >{{ v.height }}</RouterLink
                 >
               </td>
               <td class="truncate py-3" style="max-width: 200px">
                 <RouterLink
                   :to="`/${chain}/tx/${v.txhash}`"
-                  class="text-primary dark:invert"
+                  class="text-primary"
                 >
                   {{ v.txhash }}
                 </RouterLink>

--- a/src/modules/[chain]/cosmwasm/[code_id]/transactions.vue
+++ b/src/modules/[chain]/cosmwasm/[code_id]/transactions.vue
@@ -265,7 +265,7 @@ const tab = ref('detail');
           <tr v-for="resp in txs?.tx_responses">
             <td>{{ resp.height }}</td>
             <td>
-              <div class="text-xs truncate text-primary dark:invert">
+              <div class="text-xs truncate text-primary">
                 <RouterLink :to="`/${chainStore.chainName}/tx/${resp.txhash}`">{{ resp.txhash }} </RouterLink>
               </div>
             </td>

--- a/src/modules/[chain]/cosmwasm/index.vue
+++ b/src/modules/[chain]/cosmwasm/index.vue
@@ -76,7 +76,7 @@ function gotoHistory() {
             <td>
               <RouterLink
                 :to="`/${props.chain}/cosmwasm/${v.code_id}/contracts`"
-                class="truncate max-w-[200px] block text-primary dark:invert"
+                class="truncate max-w-[200px] block text-primary"
                 :title="v.data_hash"
               >
                 {{ v.data_hash }}

--- a/src/modules/[chain]/faucet/index.vue
+++ b/src/modules/[chain]/faucet/index.vue
@@ -87,7 +87,7 @@ onMounted(() => {
           viewBox="0 0 150.000000 132.000000"
           preserveAspectRatio="xMidYMid meet"
         >
-          <g transform="translate(0.000000,132.000000) scale(0.100000,-0.100000)" fill="#666CFF" class="" stroke="none">
+          <g transform="translate(0.000000,132.000000) scale(0.100000,-0.100000)" fill="currentColor" class="text-primary" stroke="none">
             <path
               d="M500 1310 l-125 -5 -182 -315 c-100 -173 -182 -321 -182 -329 -1 -7
             81 -159 181 -337 l183 -324 372 0 371 0 186 325 c102 179 186 330 186 337 0 7

--- a/src/modules/[chain]/ibc/connection/[connection_id].vue
+++ b/src/modules/[chain]/ibc/connection/[connection_id].vue
@@ -338,7 +338,7 @@ function color(v: string) {
           <tr v-for="resp in txs?.tx_responses">
             <td>{{ resp.height }}</td>
             <td>
-              <div class="text-xs truncate text-primary dark:invert">
+              <div class="text-xs truncate text-primary">
                 <RouterLink
                   :to="`/${chainStore.chainName}/tx/${resp.txhash}`"
                   >{{ resp.txhash }}</RouterLink

--- a/src/modules/[chain]/staking/index.vue
+++ b/src/modules/[chain]/staking/index.vue
@@ -337,7 +337,7 @@ loadAvatars();
                     </div>
 
                     <div class="flex flex-col">
-                      <span class="text-sm text-primary dark:invert whitespace-nowrap overflow-hidden">
+                      <span class="text-sm text-primary whitespace-nowrap overflow-hidden">
                         <RouterLink
                           :to="{
                             name: 'chain-staking-validator',

--- a/src/modules/[chain]/tx/[hash].vue
+++ b/src/modules/[chain]/tx/[hash].vue
@@ -56,7 +56,7 @@ const messages = computed(() => {
             <tr>
               <td>{{ $t('account.height') }}</td>
               <td>
-                <RouterLink :to="`/${props.chain}/block/${tx.tx_response.height}`" class="text-primary dark:invert"
+                <RouterLink :to="`/${props.chain}/block/${tx.tx_response.height}`" class="text-primary"
                   >{{ tx.tx_response.height }}
                 </RouterLink>
               </td>

--- a/src/modules/wallet/accounts.vue
+++ b/src/modules/wallet/accounts.vue
@@ -232,7 +232,8 @@ async function loadBalances(chainName: string, endpoint: string, address: string
         <div class="flex justify-self-center">
           <div class="mx-2 p-2">
             <svg
-              :fill="chainStore.current?.themeColor || '#666CFF'"
+              :fill="chainStore.current?.themeColor || 'currentColor'"
+              class="text-primary"
               height="28px"
               width="28px"
               version="1.1"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -48,8 +48,8 @@ const chainStore = useBlockchain();
         >
           <g
             transform="translate(0.000000,132.000000) scale(0.100000,-0.100000)"
-            :fill="chainStore.current?.themeColor || '#666CFF'"
-            class="dark:invert"
+            :fill="chainStore.current?.themeColor || 'currentColor'"
+            class="text-primary dark:invert"
             stroke="none"
           >
             <path

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -49,7 +49,7 @@ const chainStore = useBlockchain();
           <g
             transform="translate(0.000000,132.000000) scale(0.100000,-0.100000)"
             :fill="chainStore.current?.themeColor || 'currentColor'"
-            class="text-primary dark:invert"
+            class="text-primary"
             stroke="none"
           >
             <path
@@ -75,7 +75,7 @@ const chainStore = useBlockchain();
           </g>
         </svg>
       </div>
-      <h1 class="text-primary dark:invert text-3xl md:!text-6xl font-bold">
+      <h1 class="text-primary text-3xl md:!text-6xl font-bold">
         {{ $t('pages.title') }}
       </h1>
     </div>

--- a/src/stores/useBlockchain.ts
+++ b/src/stores/useBlockchain.ts
@@ -63,7 +63,10 @@ export const useBlockchain = defineStore('blockchain', {
           document.body.style.setProperty('--p', `${themeColor}`);
           // document.body.style.setProperty('--p', `${this.current?.themeColor}`);
         } else {
-          document.body.style.setProperty('--p', '237.65 100% 70%');
+          // Fall back to the theme's primary rather than a duplicate of it. Setting
+          // it inline here beat `daisyui.themes`, so a configured primary never
+          // applied on any chain without its own theme_color.
+          document.body.style.removeProperty('--p');
         }
         currNavItem = [
           {


### PR DESCRIPTION
This pull request introduces a comprehensive theming system using daisyUI and Tailwind, ensuring consistent color usage across the application and improving theme customizability. It removes hardcoded color values in favor of theme tokens, enhances theme override reliability when using third-party widgets, and updates documentation to guide future theming changes.

**Theming and Color System Improvements:**

* Added detailed documentation in `installation.md` explaining how to customize colors using daisyUI themes in `tailwind.config.js`, which tokens to use, and important caveats for consistent theming.
* Updated `src/components/dynamic/TextElement.vue` so link colors use the theme's `primary` token instead of a hardcoded value.
* Modified SVGs in `src/modules/[chain]/faucet/index.vue`, `src/modules/wallet/accounts.vue`, and `src/pages/index.vue` to use `currentColor` and the `text-primary` class, ensuring they follow the active theme color instead of hardcoded values. ([src/modules/[chain]/faucet/index.vueL90-R90](diffhunk://#diff-635f8f5c82ca3b53387f29b3b19567a3d4fdd8a9680971d2d4c0fbe817f012eeL90-R90), [[1]](diffhunk://#diff-b59a3d9e307dc2c1d133684d909c3d8d9a4e5237c499632d41247de8382cfdaeL235-R236) [[2]](diffhunk://#diff-d1d3d0d7da129e3558c4aedcfaa6a8ed649a34fa2989b6fdb07be735eb3289f2L51-R52)
* Changed the fallback behavior in `src/stores/useBlockchain.ts` to remove the inline `--p` variable, allowing the theme's configured `primary` color to apply as intended.

**Theme Override Reliability:**

* Introduced a custom PostCSS plugin in `postcss.config.js` that increases the specificity of daisyUI theme rules, ensuring the app’s theme settings reliably override those injected by `@ping-pub/widget`.