### PR TITLE
fix(json): replace vue3-json-viewer, whose tree renders on top of itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
     "vite-plugin-vue-layouts": "^0.7.0",
     "vue": "^3.2.45",
     "vue-i18n": "^9.2.2",
+    "vue-json-pretty": "^2.6.0",
     "vue-prism-component": "^2.0.0",
     "vue-router": "^4.1.6",
     "vue3-apexcharts": "^1.4.1",
-    "vue3-json-viewer": "^2.2.2",
     "vue3-perfect-scrollbar": "^1.6.1"
   },
   "devDependencies": {

--- a/src/components/JsonTree.vue
+++ b/src/components/JsonTree.vue
@@ -1,0 +1,75 @@
+<script lang="ts" setup>
+import { ref, watch } from 'vue';
+import VueJsonPretty from 'vue-json-pretty';
+import 'vue-json-pretty/lib/styles.css';
+import { useBaseStore } from '@/stores';
+
+// Wraps vue-json-pretty with the controls every JSON panel needs, so the copy
+// action is not reimplemented (or forgotten) at each call site.
+const props = defineProps({
+  data: { type: null, required: true },
+  // How many levels are open initially.
+  deep: { type: Number, default: 2 },
+  // Virtual scrolling keeps a large document to a handful of DOM rows, but needs
+  // a fixed height. Off by default so short results size to their content.
+  virtual: { type: Boolean, default: false },
+  height: { type: Number, default: 480 },
+});
+
+const baseStore = useBaseStore();
+
+const depth = ref(props.deep);
+const expanded = ref(false);
+const copied = ref(false);
+let resetCopied: ReturnType<typeof setTimeout> | undefined;
+
+// A new result should start collapsed again rather than inherit the last state.
+watch(
+  () => props.data,
+  () => {
+    expanded.value = false;
+    depth.value = props.deep;
+  }
+);
+
+function toggle() {
+  expanded.value = !expanded.value;
+  // 1 leaves only the top level open; MAX_SAFE_INTEGER opens every branch.
+  depth.value = expanded.value ? Number.MAX_SAFE_INTEGER : 1;
+}
+
+async function copy() {
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(props.data, null, 2));
+    copied.value = true;
+    clearTimeout(resetCopied);
+    resetCopied = setTimeout(() => (copied.value = false), 1500);
+  } catch (err) {
+    console.error('Could not copy JSON to the clipboard:', err);
+  }
+}
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center justify-end gap-1 mb-1">
+      <button type="button" class="btn btn-xs btn-ghost" @click="toggle">
+        {{ expanded ? $t('json.collapse_all') : $t('json.expand_all') }}
+      </button>
+      <button type="button" class="btn btn-xs btn-ghost" @click="copy">
+        {{ copied ? $t('json.copied') : $t('json.copy') }}
+      </button>
+    </div>
+    <VueJsonPretty
+      :data="data"
+      :deep="depth"
+      :theme="baseStore.theme || 'dark'"
+      :virtual="virtual"
+      :height="height"
+      :item-height="20"
+      :show-line-number="virtual"
+      show-icon
+      show-length
+    />
+  </div>
+</template>

--- a/src/components/WasmVerification.vue
+++ b/src/components/WasmVerification.vue
@@ -9,7 +9,8 @@ import { useWasmStore } from '@/modules/[chain]/cosmwasm/WasmStore';
 import { toBase64 } from '@cosmjs/encoding';
 import DOMPurify from 'dompurify';
 
-import { JsonViewer } from 'vue3-json-viewer';
+import VueJsonPretty from 'vue-json-pretty';
+import 'vue-json-pretty/lib/styles.css';
 import { CosmjsOfflineSigner } from '@leapwallet/cosmos-snap-provider';
 
 interface Verification {
@@ -243,15 +244,13 @@ function callFunction(title: string, method: string, arg: Argument) {
                   <label v-else class="btn btn-sm" @click="callFunction(title, method, props)">{{ method }}</label>
                 </div>
                 <div v-if="result[`${title}-${method}`]" class="mt-2">
-                  <JsonViewer
-                    :value="result[`${title}-${method}`]"
-                    :theme="baseStore.theme || 'dark'"
-                    style="background: transparent"
-                    copyable
-                    boxed
-                    sort
-                    :expand-depth="5"
-                  />
+                  <VueJsonPretty
+        :data="result[`${title}-${method}`]"
+        :deep="2"
+        :theme="baseStore.theme || 'dark'"
+        show-icon
+        show-length
+      />
                 </div>
               </div>
             </div>

--- a/src/components/WasmVerification.vue
+++ b/src/components/WasmVerification.vue
@@ -9,8 +9,7 @@ import { useWasmStore } from '@/modules/[chain]/cosmwasm/WasmStore';
 import { toBase64 } from '@cosmjs/encoding';
 import DOMPurify from 'dompurify';
 
-import VueJsonPretty from 'vue-json-pretty';
-import 'vue-json-pretty/lib/styles.css';
+import JsonTree from '@/components/JsonTree.vue';
 import { CosmjsOfflineSigner } from '@leapwallet/cosmos-snap-provider';
 
 interface Verification {
@@ -244,13 +243,7 @@ function callFunction(title: string, method: string, arg: Argument) {
                   <label v-else class="btn btn-sm" @click="callFunction(title, method, props)">{{ method }}</label>
                 </div>
                 <div v-if="result[`${title}-${method}`]" class="mt-2">
-                  <VueJsonPretty
-        :data="result[`${title}-${method}`]"
-        :deep="2"
-        :theme="baseStore.theme || 'dark'"
-        show-icon
-        show-length
-      />
+                  <JsonTree :data="result[`${title}-${method}`]" :deep="2" />
                 </div>
               </div>
             </div>

--- a/src/modules/[chain]/cosmwasm/[code_id]/transactions.vue
+++ b/src/modules/[chain]/cosmwasm/[code_id]/transactions.vue
@@ -18,8 +18,7 @@ import DynamicComponent from '@/components/dynamic/DynamicComponent.vue';
 import { useRoute } from 'vue-router';
 import type { ContractInfo, PaginabledContractStates } from '../types';
 
-import VueJsonPretty from 'vue-json-pretty';
-import 'vue-json-pretty/lib/styles.css';
+import JsonTree from '@/components/JsonTree.vue';
 
 const chainStore = useBlockchain();
 const baseStore = useBaseStore();
@@ -192,18 +191,12 @@ const tab = ref('detail');
           <div class="text-lg">{{ $t('cosmwasm.contract_states') }}</div>
         </div>
         <div class="overflow-auto">
-          <VueJsonPretty
-        :data="
+          <JsonTree :data="
               state.models?.map((v) => ({
                 key: format.hexToString(v.key),
                 value: JSON.parse(format.base64ToString(v.value)),
               })) || ''
-            "
-        :deep="2"
-        :theme="baseStore.theme || 'dark'"
-        show-icon
-        show-length
-      />
+            " :deep="2" />
           <PaginationBar :limit="pageRequest.limit" :total="state.pagination?.total" :callback="pageloadState" />
         </div>
       </div>
@@ -338,13 +331,7 @@ const tab = ref('detail');
       <div class="flex items-center justify-between px-3 pt-2 mb-4">
         <div class="text-lg font-semibold">{{ $t('cosmwasm.result') }}</div>
       </div>
-      <VueJsonPretty
-        :data="result"
-        :deep="2"
-        :theme="baseStore.theme"
-        show-icon
-        show-length
-      />
+      <JsonTree :data="result" :deep="2" />
     </div>
   </div>
 </template>

--- a/src/modules/[chain]/cosmwasm/[code_id]/transactions.vue
+++ b/src/modules/[chain]/cosmwasm/[code_id]/transactions.vue
@@ -18,9 +18,8 @@ import DynamicComponent from '@/components/dynamic/DynamicComponent.vue';
 import { useRoute } from 'vue-router';
 import type { ContractInfo, PaginabledContractStates } from '../types';
 
-import { JsonViewer } from 'vue3-json-viewer';
-// if you used v1.0.5 or latster ,you should add import "vue3-json-viewer/dist/index.css"
-import 'vue3-json-viewer/dist/index.css';
+import VueJsonPretty from 'vue-json-pretty';
+import 'vue-json-pretty/lib/styles.css';
 
 const chainStore = useBlockchain();
 const baseStore = useBaseStore();
@@ -193,20 +192,18 @@ const tab = ref('detail');
           <div class="text-lg">{{ $t('cosmwasm.contract_states') }}</div>
         </div>
         <div class="overflow-auto">
-          <JsonViewer
-            :value="
+          <VueJsonPretty
+        :data="
               state.models?.map((v) => ({
                 key: format.hexToString(v.key),
                 value: JSON.parse(format.base64ToString(v.value)),
               })) || ''
             "
-            :theme="baseStore.theme || 'dark'"
-            style="background: transparent"
-            copyable
-            boxed
-            sort
-            :expand-depth="5"
-          />
+        :deep="2"
+        :theme="baseStore.theme || 'dark'"
+        show-icon
+        show-length
+      />
           <PaginationBar :limit="pageRequest.limit" :total="state.pagination?.total" :callback="pageloadState" />
         </div>
       </div>
@@ -341,14 +338,12 @@ const tab = ref('detail');
       <div class="flex items-center justify-between px-3 pt-2 mb-4">
         <div class="text-lg font-semibold">{{ $t('cosmwasm.result') }}</div>
       </div>
-      <JsonViewer
-        :value="result"
+      <VueJsonPretty
+        :data="result"
+        :deep="2"
         :theme="baseStore.theme"
-        style="background: transparent"
-        copyable
-        boxed
-        sort
-        :expand-depth="5"
+        show-icon
+        show-length
       />
     </div>
   </div>

--- a/src/modules/[chain]/tx/[hash].vue
+++ b/src/modules/[chain]/tx/[hash].vue
@@ -4,8 +4,7 @@ import DynamicComponent from '@/components/dynamic/DynamicComponent.vue';
 import { computed, ref } from '@vue/reactivity';
 import type { Tx, TxResponse } from '@/types';
 
-import VueJsonPretty from 'vue-json-pretty';
-import 'vue-json-pretty/lib/styles.css';
+import JsonTree from '@/components/JsonTree.vue';
 
 const props = defineProps(['hash', 'chain']);
 
@@ -32,28 +31,6 @@ const messages = computed(() => {
     }) || []
   );
 });
-
-// JSON viewer controls. `deep` is reactive, so re-assigning it expands or
-// collapses the whole tree; 1 leaves only the top level open.
-const JSON_DEFAULT_DEPTH = 2;
-const jsonDepth = ref(JSON_DEFAULT_DEPTH);
-const jsonExpanded = ref(false);
-const copied = ref(false);
-
-function toggleJson() {
-  jsonExpanded.value = !jsonExpanded.value;
-  jsonDepth.value = jsonExpanded.value ? Number.MAX_SAFE_INTEGER : 1;
-}
-
-async function copyJson() {
-  try {
-    await navigator.clipboard.writeText(JSON.stringify(tx.value, null, 2));
-    copied.value = true;
-    setTimeout(() => (copied.value = false), 1500);
-  } catch (err) {
-    console.error('Could not copy JSON to the clipboard:', err);
-  }
-}
 
 </script>
 <template>
@@ -139,28 +116,8 @@ async function copyJson() {
     </div>
 
     <div v-if="tx.tx_response" class="bg-base-100 px-4 pt-3 pb-4 rounded shadow">
-      <div class="flex items-center justify-between gap-2 mb-2">
-        <h2 class="card-title truncate">JSON</h2>
-        <div class="flex items-center gap-1">
-          <button class="btn btn-xs btn-ghost" @click="toggleJson">
-            {{ jsonExpanded ? $t('tx.collapse_all') : $t('tx.expand_all') }}
-          </button>
-          <button class="btn btn-xs btn-ghost" @click="copyJson">
-            {{ copied ? $t('tx.copied') : $t('tx.copy') }}
-          </button>
-        </div>
-      </div>
-      <VueJsonPretty
-        :data="tx"
-        :deep="jsonDepth"
-        :theme="baseStore.theme"
-        :height="480"
-        :item-height="20"
-        show-icon
-        show-length
-        show-line-number
-        virtual
-      />
+      <h2 class="card-title truncate mb-2">JSON</h2>
+      <JsonTree :data="tx" :deep="2" :height="480" virtual />
     </div>
   </div>
 </template>

--- a/src/modules/[chain]/tx/[hash].vue
+++ b/src/modules/[chain]/tx/[hash].vue
@@ -4,9 +4,8 @@ import DynamicComponent from '@/components/dynamic/DynamicComponent.vue';
 import { computed, ref } from '@vue/reactivity';
 import type { Tx, TxResponse } from '@/types';
 
-import { JsonViewer } from 'vue3-json-viewer';
-// if you used v1.0.5 or latster ,you should add import "vue3-json-viewer/dist/index.css"
-import 'vue3-json-viewer/dist/index.css';
+import VueJsonPretty from 'vue-json-pretty';
+import 'vue-json-pretty/lib/styles.css';
 
 const props = defineProps(['hash', 'chain']);
 
@@ -33,6 +32,29 @@ const messages = computed(() => {
     }) || []
   );
 });
+
+// JSON viewer controls. `deep` is reactive, so re-assigning it expands or
+// collapses the whole tree; 1 leaves only the top level open.
+const JSON_DEFAULT_DEPTH = 2;
+const jsonDepth = ref(JSON_DEFAULT_DEPTH);
+const jsonExpanded = ref(false);
+const copied = ref(false);
+
+function toggleJson() {
+  jsonExpanded.value = !jsonExpanded.value;
+  jsonDepth.value = jsonExpanded.value ? Number.MAX_SAFE_INTEGER : 1;
+}
+
+async function copyJson() {
+  try {
+    await navigator.clipboard.writeText(JSON.stringify(tx.value, null, 2));
+    copied.value = true;
+    setTimeout(() => (copied.value = false), 1500);
+  } catch (err) {
+    console.error('Could not copy JSON to the clipboard:', err);
+  }
+}
+
 </script>
 <template>
   <div>
@@ -117,15 +139,27 @@ const messages = computed(() => {
     </div>
 
     <div v-if="tx.tx_response" class="bg-base-100 px-4 pt-3 pb-4 rounded shadow">
-      <h2 class="card-title truncate mb-2">JSON</h2>
-      <JsonViewer
-        :value="tx"
+      <div class="flex items-center justify-between gap-2 mb-2">
+        <h2 class="card-title truncate">JSON</h2>
+        <div class="flex items-center gap-1">
+          <button class="btn btn-xs btn-ghost" @click="toggleJson">
+            {{ jsonExpanded ? $t('tx.collapse_all') : $t('tx.expand_all') }}
+          </button>
+          <button class="btn btn-xs btn-ghost" @click="copyJson">
+            {{ copied ? $t('tx.copied') : $t('tx.copy') }}
+          </button>
+        </div>
+      </div>
+      <VueJsonPretty
+        :data="tx"
+        :deep="jsonDepth"
         :theme="baseStore.theme"
-        style="background: transparent"
-        copyable
-        boxed
-        sort
-        expand-depth="5"
+        :height="480"
+        :item-height="20"
+        show-icon
+        show-length
+        show-line-number
+        virtual
       />
     </div>
   </div>

--- a/src/modules/[chain]/tx/[hash].vue
+++ b/src/modules/[chain]/tx/[hash].vue
@@ -1,12 +1,17 @@
 <script lang="ts" setup>
 import { useBaseStore, useBlockchain, useFormatter } from '@/stores';
 import DynamicComponent from '@/components/dynamic/DynamicComponent.vue';
-import { computed, ref } from '@vue/reactivity';
+import { computed, ref, watch } from 'vue';
 import type { Tx, TxResponse } from '@/types';
 
 import JsonTree from '@/components/JsonTree.vue';
+import { useRouter } from 'vue-router';
 
 const props = defineProps(['hash', 'chain']);
+const router = useRouter();
+const searchHash = ref('');
+const searchError = ref('');
+const hashPattern = /^[A-Fa-f\d]{64}$/;
 
 const blockchain = useBlockchain();
 const baseStore = useBaseStore();
@@ -17,8 +22,21 @@ const tx = ref(
     tx_response: TxResponse;
   }
 );
-if (props.hash) {
-  blockchain.rpc.getTx(props.hash).then((x) => (tx.value = x));
+async function loadTransaction(hash: string) {
+  tx.value = {} as { tx: Tx; tx_response: TxResponse };
+  tx.value = await blockchain.rpc.getTx(hash);
+}
+watch(() => props.hash, (hash) => {
+  if (hash) void loadTransaction(hash);
+}, { immediate: true });
+function search() {
+  const value = searchHash.value.trim();
+  if (!hashPattern.test(value)) {
+    searchError.value = 'Enter a valid 64-character transaction hash.';
+    return;
+  }
+  searchError.value = '';
+  router.push(`/${props.chain}/tx/${value.toUpperCase()}`);
 }
 const messages = computed(() => {
   return (
@@ -35,13 +53,13 @@ const messages = computed(() => {
 </script>
 <template>
   <div>
-    <div class="tabs tabs-boxed bg-transparent mb-4">
-      <RouterLink class="tab text-gray-400 uppercase" :to="`/${chain}/tx/?tab=recent`">{{
-        $t('block.recent')
-      }}</RouterLink>
-      <RouterLink class="tab text-gray-400 uppercase" :to="`/${chain}/tx/?tab=search`">Search</RouterLink>
-      <a class="tab text-gray-400 uppercase tab-active">Transaction</a>
-    </div>
+    <form class="mb-4" role="search" @submit.prevent="search">
+      <div class="join flex w-full">
+        <input v-model="searchHash" type="text" class="input join-item input-sm h-10 min-w-0 flex-1 border border-base-300 bg-base-100 px-4 focus:border-primary" placeholder="Enter transaction hash" aria-label="Transaction hash" @input="searchError = ''" />
+        <button type="submit" class="btn btn-primary join-item !h-10 !min-h-10 py-0">Search</button>
+      </div>
+      <p v-if="searchError" class="mt-2 text-sm text-error">{{ searchError }}</p>
+    </form>
 
     <div v-if="tx.tx_response" class="bg-base-100 px-4 pt-3 pb-4 rounded shadow mb-4">
       <h2 class="card-title truncate mb-2">{{ $t('tx.title') }}</h2>

--- a/src/plugins/i18n/locales/en.json
+++ b/src/plugins/i18n/locales/en.json
@@ -253,7 +253,11 @@
     "gas": "Gas",
     "fee": "Fee",
     "memo": "Memo",
-    "no_messages": "No messages"
+    "no_messages": "No messages",
+    "expand_all": "Expand all",
+    "collapse_all": "Collapse all",
+    "copy": "Copy",
+    "copied": "Copied"
   },
   "uptime": {
     "overall": "Overall",

--- a/src/plugins/i18n/locales/en.json
+++ b/src/plugins/i18n/locales/en.json
@@ -253,11 +253,7 @@
     "gas": "Gas",
     "fee": "Fee",
     "memo": "Memo",
-    "no_messages": "No messages",
-    "expand_all": "Expand all",
-    "collapse_all": "Collapse all",
-    "copy": "Copy",
-    "copied": "Copied"
+    "no_messages": "No messages"
   },
   "uptime": {
     "overall": "Overall",
@@ -303,5 +299,11 @@
     "receive": "Receive",
     "app_versions": "Application Versions",
     "node_info": "Node Information"
+  },
+  "json": {
+    "expand_all": "Expand all",
+    "collapse_all": "Collapse all",
+    "copy": "Copy",
+    "copied": "Copied"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3637,7 +3637,7 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
-clipboard@^2.0.10, clipboard@^2.0.4:
+clipboard@^2.0.4:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-2.0.11.tgz#62180360b97dd668b6b3a84ec226975762a70be5"
   integrity sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==
@@ -7705,6 +7705,11 @@ vue-i18n@^9.2.2:
     "@intlify/vue-devtools" "9.3.0"
     "@vue/devtools-api" "^6.5.0"
 
+vue-json-pretty@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/vue-json-pretty/-/vue-json-pretty-2.6.0.tgz#30f865ff59a319bd88ff5ae7461682d07b0775e1"
+  integrity sha512-glz1aBVS35EO8+S9agIl3WOQaW2cJZW192UVKTuGmryx01ZvOVWc4pR3t+5UcyY4jdOfBUgVHjcpRpcnjRhCAg==
+
 vue-json-viewer@3:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/vue-json-viewer/-/vue-json-viewer-3.0.4.tgz#c1d65515e57d4036defbbc18fa942d7fd5fb9a8b"
@@ -7745,13 +7750,6 @@ vue3-apexcharts@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/vue3-apexcharts/-/vue3-apexcharts-1.4.4.tgz#3fd5f97a79dd323d37c996a44617bb2ec9978152"
   integrity sha512-TH89uZrxGjaDvkaYAISvj8+k6Bf1rUKFillc8oJirs5XZEPiwM1ELKZQ786wz0rfPqkSHHny2lqqUCK7Rw+LcQ==
-
-vue3-json-viewer@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/vue3-json-viewer/-/vue3-json-viewer-2.2.2.tgz#43a512f378c602bb6b7f2a72adeaf7d15b443885"
-  integrity sha512-56l3XDGggnpwEqZieXsSMhNT4NhtO6d7zuSAxHo4i0UVxymyY2jRb7UMQOU1ztChKALZCAzX7DlgrsnEhxu77A==
-  dependencies:
-    clipboard "^2.0.10"
 
 vue3-perfect-scrollbar@^1.6.1:
   version "1.6.1"


### PR DESCRIPTION
The JSON block on a transaction is unreadable. vue3-json-viewer wraps its block-level .jv-node rows in an inline <span class="jv-push"> and ships no CSS rule for it, so the tree never establishes block flow: rows paint over one another and most of the document is unreachable. Measured on a real transaction:

  root .jv-node height        90px
  its subtree               262,462px
  .jv-code                   overflow: hidden, max-height 300px (the `boxed` prop)
  content clipped away       34,619 of 34,769px

Forcing display:block on .jv-push is not sufficient. This is visible on ping.pub today, on any transaction large enough to matter.

vue-json-pretty styles its rows as flex with an explicit line-height, and supports virtual scrolling - which matters here, since a single IBC transaction is ~3,900 lines. It renders 22-30 DOM rows instead of the whole tree.

The old `copyable` prop has no equivalent, so the copy action is reimplemented as a button, alongside an expand/collapse toggle. Both are behind existing i18n keys added to en.json. Line numbers are enabled, and the tree opens two levels deep rather than five, since the first two are the useful ones.

Verified on a real transaction: no overlapping rows, the toggle cycles 22 -> 30 -> 4 rendered rows, and copy puts 170,577 characters of valid JSON on the clipboard.