### PR TITLE
feat(theme): make default theme configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,9 @@ VITE_FETCH_ALL_BLOCKS=false
 # Limit for recent blocks and associated transactions displayed in the UI
 VITE_RECENT_BLOCK_LIMIT=50
 
+# Default color theme when the user has no saved preference (light or dark)
+VITE_DEFAULT_THEME=dark
+
 # URL for CoinGecko API or custom proxy
 VITE_COINGECKO_URL=https://api.coingecko.com
 

--- a/env.d.ts
+++ b/env.d.ts
@@ -11,6 +11,7 @@ interface ImportMetaEnv {
     readonly VITE_GITHUB_API_URL?: string,
     readonly VITE_PINGPUB_API_URL?: string,
     readonly VITE_IBC_USE_GITHUB_API?: string,
+    readonly VITE_DEFAULT_THEME?: 'light' | 'dark',
 }
 
 interface ImportMeta {

--- a/src/stores/useBaseStore.ts
+++ b/src/stores/useBaseStore.ts
@@ -9,6 +9,13 @@ import { fromBase64 } from '@cosmjs/encoding';
 // `"false"` is a truthy string, so compare explicitly.
 const FETCH_ALL_BLOCKS = import.meta.env.VITE_FETCH_ALL_BLOCKS === 'true';
 const RECENT_BLOCKS_LIMIT = Number(import.meta.env.VITE_RECENT_BLOCK_LIMIT) || 50;
+type Theme = 'light' | 'dark';
+const DEFAULT_THEME: Theme = import.meta.env.VITE_DEFAULT_THEME === 'light' ? 'light' : 'dark';
+
+function initialTheme(): Theme {
+  const storedTheme = window.localStorage.getItem('theme');
+  return storedTheme === 'light' || storedTheme === 'dark' ? storedTheme : DEFAULT_THEME;
+}
 
 export const useBaseStore = defineStore('baseStore', {
   state: () => {
@@ -16,7 +23,7 @@ export const useBaseStore = defineStore('baseStore', {
       earliest: {} as Block,
       latest: {} as Block,
       recents: [] as Block[],
-      theme: (window.localStorage.getItem('theme') || 'dark') as 'light' | 'dark',
+      theme: initialTheme(),
       connected: false,
     };
   },


### PR DESCRIPTION
## Summary

- add `VITE_DEFAULT_THEME` so deployments can choose the initial light or dark theme
- keep a valid saved user preference ahead of the deployment default
- preserve the existing dark default when the variable is unset or invalid

## Why

Deployments should be able to choose the initial color mode without changing application source. User-selected preferences remain persisted and continue to take precedence.

## Behavior

A stored `light` or `dark` preference is used first. When no valid preference exists, `VITE_DEFAULT_THEME=light` selects light mode; `dark`, an unset value, or any invalid value falls back to dark mode.

## Checks

- `corepack yarn type-check`
- `corepack yarn build-only`
- `VITE_DEFAULT_THEME=light corepack yarn build-only`
- `git diff --check`

## Split

Extracted from #697 so that PR remains focused on semantic theme-token styling.